### PR TITLE
feat(openclaw): add KDE webtop (linuxserver/webtop) container support

### DIFF
--- a/openclaw/Dockerfile.openclaw
+++ b/openclaw/Dockerfile.openclaw
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/opencla
 
 FROM node:22-bookworm-slim AS node-runtime
 
-FROM lscr.io/linuxserver/webtop:ubuntu-xfce
+FROM lscr.io/linuxserver/webtop:ubuntu-kde
 
 ENV PUID=1000
 ENV PGID=1000
@@ -26,11 +26,12 @@ LABEL shm_size="1gb"
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
+    libnotify-bin \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=node-runtime /usr/local /usr/local
 
-RUN npm install -g openclaw@v2026.4.15
+RUN npm install -g openclaw@v2026.4.27
 
 COPY defaults-template/.config /defaults/.config
 # Seed the runtime template under /defaults so the first /config sync gets the

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -79,7 +79,12 @@ Set these in ClawManager or `docker run` to inject into `openclaw.json`:
 | `OPENCLAW_AGENT_BOOTSTRAP_TOKEN` | agent bootstrap                      | Required. Bootstrap token for agent registration |
 | `OPENCLAW_AGENT_CONTROL_PLANE_BASE_URL` | agent bootstrap             | Required. ClawManager base URL |
 | `OPENCLAW_AGENT_INITIAL_CONFIG_REVISION_ID` | agent bootstrap      | Optional initial revision id |
-| `OPENCLAW_AGENT_OPENCLAW_COMMAND` | process management              | Optional. Defaults to `openclaw gateway` |
+| `OPENCLAW_AGENT_OPENCLAW_COMMAND` | process management              | Optional. Defaults to `openclaw gateway run` |
+| `OPENCLAW_AGENT_OPENCLAW_DOCTOR_COMMAND` | startup repair          | Optional. Defaults to `openclaw doctor --fix` |
+| `OPENCLAW_AGENT_OPENCLAW_DOCTOR_POLICY` | startup repair          | Optional. `auto` (default), `always`, or `never`; `auto` does not run doctor before the first launch, and only repairs when the gateway fails to start, exits during startup, or health does not come up |
+| `OPENCLAW_AGENT_OPENCLAW_STARTUP_HEALTH_TIMEOUT` | process management | Optional. Defaults to `90s`; wait time before auto doctor when gateway health is not ready |
+| `OPENCLAW_AGENT_STARTUP_NOTIFICATION_MESSAGE` | desktop notification | Optional. Defaults to `正在启动龙虾` |
+| `OPENCLAW_AGENT_STARTUP_REPAIR_NOTIFICATION_MESSAGE` | desktop notification | Optional. Defaults to `正在修复启动环境，可能需要 1-2 分钟` |
 
 The agent default config is stored at `/etc/openclaw-agent/config.yaml`, seeded from `/defaults/openclaw-agent/config.yaml`, and the local health/debug server listens on `:18080` by default.
 

--- a/openclaw/README.zh-CN.md
+++ b/openclaw/README.zh-CN.md
@@ -79,7 +79,12 @@ docker run -d \
 | `OPENCLAW_AGENT_BOOTSTRAP_TOKEN` | agent 启动参数                      | 必填。agent 注册使用的 bootstrap token |
 | `OPENCLAW_AGENT_CONTROL_PLANE_BASE_URL` | agent 启动参数             | 必填。ClawManager 基础地址 |
 | `OPENCLAW_AGENT_INITIAL_CONFIG_REVISION_ID` | agent 启动参数      | 可选。初始配置 revision id |
-| `OPENCLAW_AGENT_OPENCLAW_COMMAND` | 进程托管参数                  | 可选。默认是 `openclaw gateway` |
+| `OPENCLAW_AGENT_OPENCLAW_COMMAND` | 进程托管参数                  | 可选。默认是 `openclaw gateway run` |
+| `OPENCLAW_AGENT_OPENCLAW_DOCTOR_COMMAND` | 启动修复参数          | 可选。默认是 `openclaw doctor --fix` |
+| `OPENCLAW_AGENT_OPENCLAW_DOCTOR_POLICY` | 启动修复策略          | 可选。`auto`（默认）、`always` 或 `never`；`auto` 不会在首次拉起前执行 doctor，只会在 gateway 拉起失败、启动阶段退出或健康检查未就绪时自动修复 |
+| `OPENCLAW_AGENT_OPENCLAW_STARTUP_HEALTH_TIMEOUT` | 进程托管参数 | 可选。默认 `90s`；gateway 健康检查未就绪时，等待多久后触发自动 doctor |
+| `OPENCLAW_AGENT_STARTUP_NOTIFICATION_MESSAGE` | 桌面通知文案      | 可选。默认是 `正在启动龙虾` |
+| `OPENCLAW_AGENT_STARTUP_REPAIR_NOTIFICATION_MESSAGE` | 桌面通知文案 | 可选。默认是 `正在修复启动环境，可能需要 1-2 分钟` |
 
 agent 默认配置位于 `/etc/openclaw-agent/config.yaml`，初次启动时由 `/defaults/openclaw-agent/config.yaml` 填充；本地健康与调试接口默认监听 `:18080`。
 

--- a/openclaw/cmd/openclaw-agent/main.go
+++ b/openclaw/cmd/openclaw-agent/main.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/iamlovingit/clawmanager-openclaw-image/internal/bootstrap"
+	"github.com/iamlovingit/clawmanager-openclaw-image/internal/browser"
 	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
 	"github.com/iamlovingit/clawmanager-openclaw-image/internal/supervisor"
 )
@@ -28,6 +29,8 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	go browser.Launch(ctx, cfg)
 
 	if err := s.Run(ctx); err != nil {
 		log.Fatalf("run supervisor: %v", err)

--- a/openclaw/config/openclaw-agent/config.yaml
+++ b/openclaw/config/openclaw-agent/config.yaml
@@ -10,10 +10,18 @@ openclaw_command:
   - openclaw
   - gateway
   - run
+openclaw_doctor_command:
+  - openclaw
+  - doctor
+  - --fix
+openclaw_doctor_policy: auto
+startup_notification_message: 正在启动龙虾
+startup_repair_notification_message: 正在修复启动环境，可能需要 1-2 分钟
 openclaw_config_path: /config/.openclaw/openclaw.json
 openclaw_workspace_path: /config/.openclaw/workspace
 openclaw_skills_path: /config/.openclaw/workspace/skills
 openclaw_health_url: http://127.0.0.1:18789/health
+openclaw_startup_health_timeout: 90s
 heartbeat_interval: 15s
 state_report_interval: 45s
 command_poll_interval: 5s

--- a/openclaw/defaults-template/.openclaw/openclaw.json
+++ b/openclaw/defaults-template/.openclaw/openclaw.json
@@ -42,7 +42,7 @@
                 "cacheRead": 0,
                 "cacheWrite": 0
               },
-              "contextWindow": 128000,
+              "contextWindow": 200000,
               "maxTokens": 65536
             }
           ]
@@ -79,9 +79,6 @@
       "restart": true,
       "ownerDisplay": "raw"
     },
-    "session": {
-      "dmScope": "per-channel-peer"
-    },
     "channels": {},
     "gateway": {
       "port": 18789,
@@ -111,6 +108,31 @@
           "reminders.add",
           "sms.send"
         ]
+      }
+    },
+    "plugins": {
+      "entries": {
+        "bonjour": {
+          "enabled": false
+        },
+        "acpx": {
+          "enabled": false
+        },
+        "browser": {
+          "enabled": false
+        },
+        "phone-control": {
+          "enabled": false
+        },
+        "talk-voice": {
+          "enabled": false
+        },
+        "device-pair": {
+          "enabled": false
+        },
+        "dingtalk-connector": {
+          "enabled": false
+        }
       }
     }
   }

--- a/openclaw/internal/bootstrap/bootstrap.go
+++ b/openclaw/internal/bootstrap/bootstrap.go
@@ -26,6 +26,10 @@ func Run(cfg appconfig.Config) error {
 	if err := applyOwnership(cfg); err != nil {
 		return fmt.Errorf("apply ownership: %w", err)
 	}
+	if err := ensureDingtalkOpenclawSymlink(cfg); err != nil {
+		return fmt.Errorf("dingtalk openclaw symlink: %w", err)
+	}
+	raiseOpenFileLimit()
 	if err := dropPrivileges(cfg); err != nil {
 		return fmt.Errorf("drop privileges: %w", err)
 	}

--- a/openclaw/internal/bootstrap/bootstrap_test.go
+++ b/openclaw/internal/bootstrap/bootstrap_test.go
@@ -96,6 +96,34 @@ func TestEnsureExtensionsDirCreates(t *testing.T) {
 	}
 }
 
+func TestEnsureDingtalkOpenclawSymlinkCreates(t *testing.T) {
+	global := filepath.Join(t.TempDir(), "openclaw")
+	if err := os.MkdirAll(global, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := openclawGlobalNodeModules
+	t.Cleanup(func() { openclawGlobalNodeModules = old })
+	openclawGlobalNodeModules = global
+
+	root := t.TempDir()
+	ext := filepath.Join(root, "extensions")
+	if err := os.MkdirAll(filepath.Join(ext, "dingtalk-connector"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := appconfig.Config{OpenClawExtensionsDir: ext, DropUserName: ""}
+	if err := ensureDingtalkOpenclawSymlink(cfg); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(ext, "dingtalk-connector", "node_modules", "openclaw")
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != global {
+		t.Fatalf("link target: want %q, got %q", global, target)
+	}
+}
+
 func TestSyncAutostartInstallsOnlyMissing(t *testing.T) {
 	root := t.TempDir()
 	src := filepath.Join(root, "defaults-autostart")

--- a/openclaw/internal/bootstrap/dingtalk_symlink.go
+++ b/openclaw/internal/bootstrap/dingtalk_symlink.go
@@ -1,0 +1,67 @@
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
+)
+
+// Global openclaw package path (see Dockerfile: npm install -g openclaw).
+var openclawGlobalNodeModules = "/usr/local/lib/node_modules/openclaw"
+
+// ensureDingtalkOpenclawSymlink runs after defaults sync and applyOwnership. It
+// makes dingtalk-connector resolve the "openclaw" package the same as the
+// image-wide install: node_modules/openclaw -> /usr/local/lib/node_modules/openclaw
+func ensureDingtalkOpenclawSymlink(cfg appconfig.Config) error {
+	if cfg.OpenClawExtensionsDir == "" {
+		return nil
+	}
+	connectorDir := filepath.Join(cfg.OpenClawExtensionsDir, "dingtalk-connector")
+	if !pathExists(connectorDir) {
+		return nil
+	}
+	linkPath := filepath.Join(connectorDir, "node_modules", "openclaw")
+	parent := filepath.Dir(linkPath)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", parent, err)
+	}
+
+	if err := ensureSymlink(openclawGlobalNodeModules, linkPath); err != nil {
+		return err
+	}
+	if os.Geteuid() == 0 && cfg.DropUserName != "" {
+		uid, gid, err := lookupDropUser(cfg.DropUserName)
+		if err != nil {
+			return err
+		}
+		if err := os.Lchown(linkPath, uid, gid); err != nil {
+			return fmt.Errorf("lchown %s: %w", linkPath, err)
+		}
+	}
+	return nil
+}
+
+func ensureSymlink(target, linkPath string) error {
+	if fi, err := os.Lstat(linkPath); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			cur, rerr := os.Readlink(linkPath)
+			if rerr != nil {
+				return fmt.Errorf("readlink %s: %w", linkPath, rerr)
+			}
+			if cur == target {
+				return nil
+			}
+		}
+		if err := os.RemoveAll(linkPath); err != nil {
+			return fmt.Errorf("remove %s: %w", linkPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		return fmt.Errorf("symlink %s -> %s: %w", linkPath, target, err)
+	}
+	return nil
+}

--- a/openclaw/internal/bootstrap/rlimit_linux.go
+++ b/openclaw/internal/bootstrap/rlimit_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package bootstrap
+
+import (
+	"log"
+	"syscall"
+)
+
+const openFileLimitTarget uint64 = 65535
+
+func raiseOpenFileLimit() {
+	var current syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &current); err != nil {
+		log.Printf("bootstrap: read nofile limit failed: %v", err)
+		return
+	}
+	if current.Cur >= openFileLimitTarget {
+		return
+	}
+
+	desired := current
+	desired.Cur = openFileLimitTarget
+	if desired.Max < desired.Cur {
+		desired.Max = desired.Cur
+	}
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &desired); err == nil {
+		log.Printf("bootstrap: raised nofile limit from %d/%d to %d/%d", current.Cur, current.Max, desired.Cur, desired.Max)
+		return
+	}
+
+	if current.Max > current.Cur {
+		fallback := current
+		fallback.Cur = current.Max
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &fallback); err == nil {
+			log.Printf("bootstrap: raised nofile limit from %d/%d to %d/%d", current.Cur, current.Max, fallback.Cur, fallback.Max)
+			return
+		}
+	}
+
+	log.Printf("bootstrap: leaving nofile limit at %d/%d", current.Cur, current.Max)
+}

--- a/openclaw/internal/bootstrap/rlimit_other.go
+++ b/openclaw/internal/bootstrap/rlimit_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package bootstrap
+
+func raiseOpenFileLimit() {}

--- a/openclaw/internal/browser/launcher.go
+++ b/openclaw/internal/browser/launcher.go
@@ -1,0 +1,171 @@
+// Package browser is responsible for opening the OpenClaw control UI in
+// the user-facing Chromium browser as soon as the Wayland session is ready.
+//
+// The linuxserver/webtop:ubuntu-kde image launches `plasmashell` directly
+// without `ksmserver` (or a systemd user session that would host the
+// `systemd-xdg-autostart-generator`), so XDG autostart entries placed in
+// ~/.config/autostart never run. Rather than try to repair that machinery
+// from outside, the agent owns the launch sequence end-to-end.
+package browser
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"time"
+
+	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
+)
+
+const (
+	pollInterval        = 500 * time.Millisecond
+	agentReadyTimeout   = 10 * time.Second
+	healthClientTimeout = 2 * time.Second
+)
+
+// Launch waits for the Wayland socket and then spawns the configured browser
+// pointed at cfg.BrowserURL. It intentionally does not wait for OpenClaw
+// gateway health, because doctor and gateway startup can take long enough that
+// a blank desktop feels broken to users.
+func Launch(ctx context.Context, cfg appconfig.Config) {
+	if !cfg.BrowserAutoLaunchEnabled {
+		log.Printf("browser: auto launch disabled by config")
+		return
+	}
+	if cfg.BrowserExecutable == "" || cfg.BrowserURL == "" {
+		log.Printf("browser: missing executable or url, skipping launch")
+		return
+	}
+
+	if err := waitForWaylandSocket(ctx, cfg); err != nil {
+		log.Printf("browser: %v", err)
+		return
+	}
+	if cfg.BrowserLaunchExtraDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(cfg.BrowserLaunchExtraDelay):
+		}
+	}
+	launchURL := browserLaunchURL(ctx, cfg)
+	if err := spawnBrowser(ctx, cfg, launchURL); err != nil {
+		log.Printf("browser: spawn failed: %v", err)
+		return
+	}
+	log.Printf("browser: launched %s -> %s", cfg.BrowserExecutable, launchURL)
+}
+
+func waitForWaylandSocket(ctx context.Context, cfg appconfig.Config) error {
+	if cfg.WaylandSocketPath == "" {
+		return nil
+	}
+	deadline := time.Now().Add(cfg.BrowserLaunchWaylandTimeout)
+	for {
+		if _, err := os.Stat(cfg.WaylandSocketPath); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wayland socket %s not ready within %s", cfg.WaylandSocketPath, cfg.BrowserLaunchWaylandTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func browserLaunchURL(ctx context.Context, cfg appconfig.Config) string {
+	waitURL := openClawWaitURL(cfg)
+	if waitURL == "" {
+		return cfg.BrowserURL
+	}
+	if err := waitForAgentHTTP(ctx, waitURL); err != nil {
+		log.Printf("browser: wait page not ready, opening target directly: %v", err)
+		return cfg.BrowserURL
+	}
+	return waitURL
+}
+
+func waitForAgentHTTP(ctx context.Context, waitURL string) error {
+	parsed, err := url.Parse(waitURL)
+	if err != nil {
+		return err
+	}
+	healthURL := *parsed
+	healthURL.Path = "/healthz"
+	healthURL.RawQuery = ""
+
+	client := &http.Client{Timeout: healthClientTimeout}
+	deadline := time.Now().Add(agentReadyTimeout)
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL.String(), nil)
+		if err == nil {
+			if resp, err := client.Do(req); err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+					return nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("agent http %s not ready within %s", healthURL.String(), agentReadyTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func openClawWaitURL(cfg appconfig.Config) string {
+	if cfg.LocalHTTPBind == "" || cfg.BrowserURL == "" {
+		return ""
+	}
+	host := "127.0.0.1"
+	port := "18080"
+	if parsedHost, parsedPort, err := net.SplitHostPort(cfg.LocalHTTPBind); err == nil {
+		port = parsedPort
+		if parsedHost != "" && parsedHost != "0.0.0.0" && parsedHost != "::" && parsedHost != "[::]" {
+			host = parsedHost
+		}
+	}
+	return "http://" + net.JoinHostPort(host, port) + "/openclaw-wait?target=" + url.QueryEscape(cfg.BrowserURL)
+}
+
+func spawnBrowser(ctx context.Context, cfg appconfig.Config, launchURL string) error {
+	cmd := exec.CommandContext(ctx, cfg.BrowserExecutable, launchURL)
+	cmd.Env = browserEnv()
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return nil
+}
+
+func browserEnv() []string {
+	base := []string{
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=/config/.XDG",
+		"XDG_SESSION_TYPE=wayland",
+		"XDG_CURRENT_DESKTOP=KDE",
+		"DISPLAY=:1",
+		"HOME=/config",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+	if lang := os.Getenv("LANG"); lang != "" {
+		base = append(base, "LANG="+lang)
+	}
+	return base
+}

--- a/openclaw/internal/browser/launcher.go.4516581588507636119
+++ b/openclaw/internal/browser/launcher.go.4516581588507636119
@@ -1,0 +1,106 @@
+// Package browser is responsible for opening the OpenClaw control UI in
+// the user-facing Chromium browser as soon as the Wayland session is ready.
+//
+// The linuxserver/webtop:ubuntu-kde image launches `plasmashell` directly
+// without `ksmserver` (or a systemd user session that would host the
+// `systemd-xdg-autostart-generator`), so XDG autostart entries placed in
+// ~/.config/autostart never run. Rather than try to repair that machinery
+// from outside, the agent owns the launch sequence end-to-end.
+package browser
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
+)
+
+const (
+	pollInterval = 500 * time.Millisecond
+)
+
+// Launch waits for the Wayland socket and then spawns the configured browser
+// pointed at cfg.BrowserURL. It intentionally does not wait for OpenClaw
+// gateway health, because doctor and gateway startup can take long enough that
+// a blank desktop feels broken to users.
+func Launch(ctx context.Context, cfg appconfig.Config) {
+	if !cfg.BrowserAutoLaunchEnabled {
+		log.Printf("browser: auto launch disabled by config")
+		return
+	}
+	if cfg.BrowserExecutable == "" || cfg.BrowserURL == "" {
+		log.Printf("browser: missing executable or url, skipping launch")
+		return
+	}
+
+	if err := waitForWaylandSocket(ctx, cfg); err != nil {
+		log.Printf("browser: %v", err)
+		return
+	}
+	if cfg.BrowserLaunchExtraDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(cfg.BrowserLaunchExtraDelay):
+		}
+	}
+	if err := spawnBrowser(ctx, cfg); err != nil {
+		log.Printf("browser: spawn failed: %v", err)
+		return
+	}
+	log.Printf("browser: launched %s -> %s", cfg.BrowserExecutable, cfg.BrowserURL)
+}
+
+func waitForWaylandSocket(ctx context.Context, cfg appconfig.Config) error {
+	if cfg.WaylandSocketPath == "" {
+		return nil
+	}
+	deadline := time.Now().Add(cfg.BrowserLaunchWaylandTimeout)
+	for {
+		if _, err := os.Stat(cfg.WaylandSocketPath); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wayland socket %s not ready within %s", cfg.WaylandSocketPath, cfg.BrowserLaunchWaylandTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func spawnBrowser(ctx context.Context, cfg appconfig.Config) error {
+	cmd := exec.CommandContext(ctx, cfg.BrowserExecutable, cfg.BrowserURL)
+	cmd.Env = browserEnv()
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return nil
+}
+
+func browserEnv() []string {
+	base := []string{
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_RUNTIME_DIR=/config/.XDG",
+		"XDG_SESSION_TYPE=wayland",
+		"XDG_CURRENT_DESKTOP=KDE",
+		"DISPLAY=:1",
+		"HOME=/config",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+	if lang := os.Getenv("LANG"); lang != "" {
+		base = append(base, "LANG="+lang)
+	}
+	return base
+}

--- a/openclaw/internal/config/config.go
+++ b/openclaw/internal/config/config.go
@@ -17,77 +17,102 @@ const (
 )
 
 type Config struct {
-	InstanceID                   string        `yaml:"instance_id"`
-	BootstrapToken               string        `yaml:"bootstrap_token"`
-	ControlPlaneBaseURL          string        `yaml:"control_plane_base_url"`
-	AgentDataDir                 string        `yaml:"agent_data_dir"`
-	DiskUsagePath                string        `yaml:"disk_usage_path"`
-	DiskLimitBytes               uint64        `yaml:"disk_limit_bytes"`
-	InitialConfigRevisionID      string        `yaml:"initial_config_revision_id"`
-	ProtocolVersion              string        `yaml:"protocol_version"`
-	LocalHTTPBind                string        `yaml:"local_http_bind"`
-	LogFilePath                  string        `yaml:"log_file_path"`
-	OpenClawCommand              []string      `yaml:"openclaw_command"`
-	OpenClawConfigPath           string        `yaml:"openclaw_config_path"`
-	OpenClawWorkspacePath        string        `yaml:"openclaw_workspace_path"`
-	OpenClawSkillsPath           string        `yaml:"openclaw_skills_path"`
-	OpenClawBuiltinSkillsPath    string        `yaml:"openclaw_builtin_skills_path"`
-	OpenClawHealthURL            string        `yaml:"openclaw_health_url"`
-	OpenClawDefaultsDir          string        `yaml:"openclaw_defaults_dir"`
-	AutostartDefaultsDir         string        `yaml:"autostart_defaults_dir"`
-	AutostartTargetDir           string        `yaml:"autostart_target_dir"`
-	OpenClawExtensionsDir        string        `yaml:"openclaw_extensions_dir"`
-	OpenClawBundledExtensionsDir string        `yaml:"openclaw_bundled_extensions_dir"`
-	InstalledPluginPathPrefix    string        `yaml:"installed_plugin_path_prefix"`
-	DropUserName                 string        `yaml:"drop_user_name"`
-	HeartbeatInterval            time.Duration `yaml:"-"`
-	StateReportInterval          time.Duration `yaml:"-"`
-	CommandPollInterval          time.Duration `yaml:"-"`
-	CommandPollBackoffMax        time.Duration `yaml:"-"`
-	RegisterRetryInterval        time.Duration `yaml:"-"`
-	ProcessStopTimeout           time.Duration `yaml:"-"`
-	SkillIncrementalInterval     time.Duration `yaml:"-"`
-	SkillFullSyncInterval        time.Duration `yaml:"-"`
-	MaxAutoRestart               int           `yaml:"max_auto_restart"`
-	HeartbeatIntervalRaw         string        `yaml:"heartbeat_interval"`
-	StateReportIntervalRaw       string        `yaml:"state_report_interval"`
-	CommandPollIntervalRaw       string        `yaml:"command_poll_interval"`
-	CommandPollBackoffMaxRaw     string        `yaml:"command_poll_backoff_max"`
-	RegisterRetryIntervalRaw     string        `yaml:"register_retry_interval"`
-	ProcessStopTimeoutRaw        string        `yaml:"process_stop_timeout"`
-	SkillIncrementalRaw          string        `yaml:"skill_incremental_interval"`
-	SkillFullSyncRaw             string        `yaml:"skill_full_sync_interval"`
+	InstanceID                       string        `yaml:"instance_id"`
+	BootstrapToken                   string        `yaml:"bootstrap_token"`
+	ControlPlaneBaseURL              string        `yaml:"control_plane_base_url"`
+	AgentDataDir                     string        `yaml:"agent_data_dir"`
+	DiskUsagePath                    string        `yaml:"disk_usage_path"`
+	DiskLimitBytes                   uint64        `yaml:"disk_limit_bytes"`
+	InitialConfigRevisionID          string        `yaml:"initial_config_revision_id"`
+	ProtocolVersion                  string        `yaml:"protocol_version"`
+	LocalHTTPBind                    string        `yaml:"local_http_bind"`
+	LogFilePath                      string        `yaml:"log_file_path"`
+	OpenClawCommand                  []string      `yaml:"openclaw_command"`
+	OpenClawDoctorCommand            []string      `yaml:"openclaw_doctor_command"`
+	OpenClawDoctorPolicy             string        `yaml:"openclaw_doctor_policy"`
+	StartupNotificationMessage       string        `yaml:"startup_notification_message"`
+	StartupRepairNotificationMessage string        `yaml:"startup_repair_notification_message"`
+	OpenClawConfigPath               string        `yaml:"openclaw_config_path"`
+	OpenClawWorkspacePath            string        `yaml:"openclaw_workspace_path"`
+	OpenClawSkillsPath               string        `yaml:"openclaw_skills_path"`
+	OpenClawBuiltinSkillsPath        string        `yaml:"openclaw_builtin_skills_path"`
+	OpenClawHealthURL                string        `yaml:"openclaw_health_url"`
+	OpenClawStartupHealthTimeoutRaw  string        `yaml:"openclaw_startup_health_timeout"`
+	OpenClawDefaultsDir              string        `yaml:"openclaw_defaults_dir"`
+	AutostartDefaultsDir             string        `yaml:"autostart_defaults_dir"`
+	AutostartTargetDir               string        `yaml:"autostart_target_dir"`
+	OpenClawExtensionsDir            string        `yaml:"openclaw_extensions_dir"`
+	OpenClawBundledExtensionsDir     string        `yaml:"openclaw_bundled_extensions_dir"`
+	InstalledPluginPathPrefix        string        `yaml:"installed_plugin_path_prefix"`
+	DropUserName                     string        `yaml:"drop_user_name"`
+	BrowserAutoLaunchEnabled         bool          `yaml:"browser_auto_launch_enabled"`
+	BrowserExecutable                string        `yaml:"browser_executable"`
+	BrowserURL                       string        `yaml:"browser_url"`
+	WaylandSocketPath                string        `yaml:"wayland_socket_path"`
+	BrowserLaunchWaylandTimeoutRaw   string        `yaml:"browser_launch_wayland_timeout"`
+	BrowserLaunchExtraDelayRaw       string        `yaml:"browser_launch_extra_delay"`
+	BrowserLaunchWaylandTimeout      time.Duration `yaml:"-"`
+	BrowserLaunchExtraDelay          time.Duration `yaml:"-"`
+	OpenClawStartupHealthTimeout     time.Duration `yaml:"-"`
+	HeartbeatInterval                time.Duration `yaml:"-"`
+	StateReportInterval              time.Duration `yaml:"-"`
+	CommandPollInterval              time.Duration `yaml:"-"`
+	CommandPollBackoffMax            time.Duration `yaml:"-"`
+	RegisterRetryInterval            time.Duration `yaml:"-"`
+	ProcessStopTimeout               time.Duration `yaml:"-"`
+	SkillIncrementalInterval         time.Duration `yaml:"-"`
+	SkillFullSyncInterval            time.Duration `yaml:"-"`
+	MaxAutoRestart                   int           `yaml:"max_auto_restart"`
+	HeartbeatIntervalRaw             string        `yaml:"heartbeat_interval"`
+	StateReportIntervalRaw           string        `yaml:"state_report_interval"`
+	CommandPollIntervalRaw           string        `yaml:"command_poll_interval"`
+	CommandPollBackoffMaxRaw         string        `yaml:"command_poll_backoff_max"`
+	RegisterRetryIntervalRaw         string        `yaml:"register_retry_interval"`
+	ProcessStopTimeoutRaw            string        `yaml:"process_stop_timeout"`
+	SkillIncrementalRaw              string        `yaml:"skill_incremental_interval"`
+	SkillFullSyncRaw                 string        `yaml:"skill_full_sync_interval"`
 }
 
 func Load() (Config, error) {
 	cfg := Config{
-		AgentDataDir:                 "/var/lib/openclaw-agent",
-		DiskUsagePath:                "/config",
-		ProtocolVersion:              "v1",
-		LocalHTTPBind:                "0.0.0.0:18080",
-		LogFilePath:                  "/var/log/openclaw-agent/agent.log",
-		OpenClawCommand:              []string{"openclaw", "gateway", "run"},
-		OpenClawConfigPath:           "/config/.openclaw/openclaw.json",
-		OpenClawWorkspacePath:        "/config/.openclaw/workspace",
-		OpenClawSkillsPath:           "/config/.openclaw/workspace/skills",
-		OpenClawBuiltinSkillsPath:    "/usr/lib/node_modules/openclaw/skills",
-		OpenClawHealthURL:            "http://127.0.0.1:18789/health",
-		OpenClawDefaultsDir:          "/defaults/.openclaw",
-		AutostartDefaultsDir:         "/defaults/.config/autostart",
-		AutostartTargetDir:           "/config/.config/autostart",
-		OpenClawExtensionsDir:        "/config/.openclaw/extensions",
-		OpenClawBundledExtensionsDir: "/usr/local/lib/node_modules/openclaw/dist/extensions",
-		InstalledPluginPathPrefix:    "/defaults/.openclaw/extensions/",
-		DropUserName:                 "abc",
-		HeartbeatIntervalRaw:         "15s",
-		StateReportIntervalRaw:       "45s",
-		CommandPollIntervalRaw:       "5s",
-		CommandPollBackoffMaxRaw:     "60s",
-		RegisterRetryIntervalRaw:     "10s",
-		ProcessStopTimeoutRaw:        "20s",
-		SkillIncrementalRaw:          "30s",
-		SkillFullSyncRaw:             "12h",
-		MaxAutoRestart:               3,
+		AgentDataDir:                     "/var/lib/openclaw-agent",
+		DiskUsagePath:                    "/config",
+		ProtocolVersion:                  "v1",
+		LocalHTTPBind:                    "0.0.0.0:18080",
+		LogFilePath:                      "/var/log/openclaw-agent/agent.log",
+		OpenClawCommand:                  []string{"openclaw", "gateway", "run"},
+		OpenClawDoctorCommand:            []string{"openclaw", "doctor", "--fix"},
+		OpenClawDoctorPolicy:             "auto",
+		StartupNotificationMessage:       "正在启动龙虾",
+		StartupRepairNotificationMessage: "正在修复启动环境，可能需要 1-2 分钟",
+		OpenClawConfigPath:               "/config/.openclaw/openclaw.json",
+		OpenClawWorkspacePath:            "/config/.openclaw/workspace",
+		OpenClawSkillsPath:               "/config/.openclaw/workspace/skills",
+		OpenClawBuiltinSkillsPath:        "/usr/lib/node_modules/openclaw/skills",
+		OpenClawHealthURL:                "http://127.0.0.1:18789/health",
+		OpenClawStartupHealthTimeoutRaw:  "90s",
+		OpenClawDefaultsDir:              "/defaults/.openclaw",
+		AutostartDefaultsDir:             "/defaults/.config/autostart",
+		AutostartTargetDir:               "/config/.config/autostart",
+		OpenClawExtensionsDir:            "/config/.openclaw/extensions",
+		OpenClawBundledExtensionsDir:     "/usr/local/lib/node_modules/openclaw/dist/extensions",
+		InstalledPluginPathPrefix:        "/defaults/.openclaw/extensions/",
+		DropUserName:                     "abc",
+		BrowserAutoLaunchEnabled:         true,
+		BrowserExecutable:                "/usr/bin/chromium",
+		BrowserURL:                       "http://localhost:18789",
+		WaylandSocketPath:                "/config/.XDG/wayland-0",
+		BrowserLaunchWaylandTimeoutRaw:   "60s",
+		BrowserLaunchExtraDelayRaw:       "0s",
+		HeartbeatIntervalRaw:             "15s",
+		StateReportIntervalRaw:           "45s",
+		CommandPollIntervalRaw:           "5s",
+		CommandPollBackoffMaxRaw:         "60s",
+		RegisterRetryIntervalRaw:         "10s",
+		ProcessStopTimeoutRaw:            "20s",
+		SkillIncrementalRaw:              "30s",
+		SkillFullSyncRaw:                 "12h",
+		MaxAutoRestart:                   3,
 	}
 
 	path := envOrDefault("OPENCLAW_AGENT_CONFIG_PATH", defaultConfigPath)
@@ -108,11 +133,14 @@ func Load() (Config, error) {
 	overrideStringAny(&cfg.ProtocolVersion, "OPENCLAW_AGENT_PROTOCOL_VERSION", "CLAWMANAGER_AGENT_PROTOCOL_VERSION")
 	overrideStringAny(&cfg.LocalHTTPBind, "OPENCLAW_AGENT_LOCAL_HTTP_BIND")
 	overrideStringAny(&cfg.LogFilePath, "OPENCLAW_AGENT_LOG_FILE_PATH")
+	overrideStringAny(&cfg.StartupNotificationMessage, "OPENCLAW_AGENT_STARTUP_NOTIFICATION_MESSAGE")
+	overrideStringAny(&cfg.StartupRepairNotificationMessage, "OPENCLAW_AGENT_STARTUP_REPAIR_NOTIFICATION_MESSAGE")
 	overrideStringAny(&cfg.OpenClawConfigPath, "OPENCLAW_AGENT_OPENCLAW_CONFIG_PATH")
 	overrideStringAny(&cfg.OpenClawWorkspacePath, "OPENCLAW_AGENT_OPENCLAW_WORKSPACE_PATH")
 	overrideStringAny(&cfg.OpenClawSkillsPath, "OPENCLAW_AGENT_OPENCLAW_SKILLS_PATH")
 	overrideStringAny(&cfg.OpenClawBuiltinSkillsPath, "OPENCLAW_AGENT_OPENCLAW_BUILTIN_SKILLS_PATH")
 	overrideStringAny(&cfg.OpenClawHealthURL, "OPENCLAW_AGENT_OPENCLAW_HEALTH_URL")
+	overrideStringAny(&cfg.OpenClawStartupHealthTimeoutRaw, "OPENCLAW_AGENT_OPENCLAW_STARTUP_HEALTH_TIMEOUT")
 	overrideStringAny(&cfg.OpenClawDefaultsDir, "OPENCLAW_AGENT_OPENCLAW_DEFAULTS_DIR")
 	overrideStringAny(&cfg.AutostartDefaultsDir, "OPENCLAW_AGENT_AUTOSTART_DEFAULTS_DIR")
 	overrideStringAny(&cfg.AutostartTargetDir, "OPENCLAW_AGENT_AUTOSTART_TARGET_DIR")
@@ -120,6 +148,12 @@ func Load() (Config, error) {
 	overrideStringAny(&cfg.OpenClawBundledExtensionsDir, "OPENCLAW_AGENT_OPENCLAW_BUNDLED_EXTENSIONS_DIR")
 	overrideStringAny(&cfg.InstalledPluginPathPrefix, "OPENCLAW_AGENT_INSTALLED_PLUGIN_PATH_PREFIX")
 	overrideStringAny(&cfg.DropUserName, "OPENCLAW_AGENT_DROP_USER_NAME")
+	overrideBoolAny(&cfg.BrowserAutoLaunchEnabled, "OPENCLAW_AGENT_BROWSER_AUTO_LAUNCH_ENABLED")
+	overrideStringAny(&cfg.BrowserExecutable, "OPENCLAW_AGENT_BROWSER_EXECUTABLE")
+	overrideStringAny(&cfg.BrowserURL, "OPENCLAW_AGENT_BROWSER_URL")
+	overrideStringAny(&cfg.WaylandSocketPath, "OPENCLAW_AGENT_WAYLAND_SOCKET_PATH")
+	overrideStringAny(&cfg.BrowserLaunchWaylandTimeoutRaw, "OPENCLAW_AGENT_BROWSER_LAUNCH_WAYLAND_TIMEOUT")
+	overrideStringAny(&cfg.BrowserLaunchExtraDelayRaw, "OPENCLAW_AGENT_BROWSER_LAUNCH_EXTRA_DELAY")
 	overrideStringAny(&cfg.HeartbeatIntervalRaw, "OPENCLAW_AGENT_HEARTBEAT_INTERVAL")
 	overrideStringAny(&cfg.StateReportIntervalRaw, "OPENCLAW_AGENT_STATE_REPORT_INTERVAL")
 	overrideStringAny(&cfg.CommandPollIntervalRaw, "OPENCLAW_AGENT_COMMAND_POLL_INTERVAL")
@@ -132,6 +166,10 @@ func Load() (Config, error) {
 	if raw := envFirst("OPENCLAW_AGENT_OPENCLAW_COMMAND"); raw != "" {
 		cfg.OpenClawCommand = strings.Fields(raw)
 	}
+	if raw := envFirst("OPENCLAW_AGENT_OPENCLAW_DOCTOR_COMMAND"); raw != "" {
+		cfg.OpenClawDoctorCommand = strings.Fields(raw)
+	}
+	overrideStringAny(&cfg.OpenClawDoctorPolicy, "OPENCLAW_AGENT_OPENCLAW_DOCTOR_POLICY")
 	if raw := envFirst("OPENCLAW_AGENT_MAX_AUTO_RESTART"); raw != "" {
 		n, err := strconv.Atoi(raw)
 		if err != nil {
@@ -172,6 +210,15 @@ func Load() (Config, error) {
 	if cfg.SkillFullSyncInterval, err = time.ParseDuration(cfg.SkillFullSyncRaw); err != nil {
 		return Config{}, fmt.Errorf("parse skill_full_sync_interval: %w", err)
 	}
+	if cfg.BrowserLaunchWaylandTimeout, err = time.ParseDuration(cfg.BrowserLaunchWaylandTimeoutRaw); err != nil {
+		return Config{}, fmt.Errorf("parse browser_launch_wayland_timeout: %w", err)
+	}
+	if cfg.BrowserLaunchExtraDelay, err = time.ParseDuration(cfg.BrowserLaunchExtraDelayRaw); err != nil {
+		return Config{}, fmt.Errorf("parse browser_launch_extra_delay: %w", err)
+	}
+	if cfg.OpenClawStartupHealthTimeout, err = time.ParseDuration(cfg.OpenClawStartupHealthTimeoutRaw); err != nil {
+		return Config{}, fmt.Errorf("parse openclaw_startup_health_timeout: %w", err)
+	}
 
 	if cfg.InstanceID == "" {
 		return Config{}, errors.New("instance_id is required")
@@ -209,6 +256,19 @@ func overrideString(target *string, envKey string) {
 func overrideStringAny(target *string, envKeys ...string) {
 	if value := envFirst(envKeys...); value != "" {
 		*target = value
+	}
+}
+
+func overrideBoolAny(target *bool, envKeys ...string) {
+	value := envFirst(envKeys...)
+	if value == "" {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		*target = true
+	case "0", "false", "no", "off":
+		*target = false
 	}
 }
 

--- a/openclaw/internal/configmanager/channels.go
+++ b/openclaw/internal/configmanager/channels.go
@@ -98,23 +98,28 @@ func rewriteInstalledPluginPaths(cfg map[string]any, prefix, userExtensionsDir s
 	if !ok {
 		return
 	}
-	installs, ok := plugins["installs"].(map[string]any)
-	if !ok {
-		return
-	}
-	for _, entry := range installs {
-		install, ok := entry.(map[string]any)
-		if !ok {
-			continue
+	rewritePluginPathStrings(plugins, prefix, userExtensionsDir)
+}
+
+func rewritePluginPathStrings(value any, prefix, userExtensionsDir string) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			typed[key] = rewritePluginPathStrings(child, prefix, userExtensionsDir)
 		}
-		installPath, ok := install["installPath"].(string)
-		if !ok {
-			continue
+		return typed
+	case []any:
+		for i, child := range typed {
+			typed[i] = rewritePluginPathStrings(child, prefix, userExtensionsDir)
 		}
-		if !strings.HasPrefix(installPath, prefix) {
-			continue
+		return typed
+	case string:
+		if strings.HasPrefix(typed, prefix) {
+			return path.Join(userExtensionsDir, typed[len(prefix):])
 		}
-		install["installPath"] = path.Join(userExtensionsDir, installPath[len(prefix):])
+		return typed
+	default:
+		return typed
 	}
 }
 

--- a/openclaw/internal/configmanager/model_guard.go.8137295903977164534
+++ b/openclaw/internal/configmanager/model_guard.go.8137295903977164534
@@ -1,0 +1,210 @@
+package configmanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const (
+	agentsKey          = "agents"
+	defaultsKey        = "defaults"
+	defaultModelKey    = "model"
+	modelsKey          = "models"
+	providersKey       = "providers"
+	autoProviderKey    = "auto"
+	baseURLKey         = "baseUrl"
+	apiKeyKey          = "apiKey"
+	providerModelsKey  = "models"
+)
+
+type modelBaselineEntry struct {
+	path   []string
+	value  any
+	exists bool
+}
+
+func modelGuardPaths() [][]string {
+	return [][]string{
+		{modelsKey, providersKey, autoProviderKey, baseURLKey},
+		{modelsKey, providersKey, autoProviderKey, apiKeyKey},
+		{modelsKey, providersKey, autoProviderKey, providerModelsKey},
+		{agentsKey, defaultsKey, defaultModelKey},
+	}
+}
+
+// CaptureModelBaseline snapshots model-related fields from the current
+// openclaw.json, which are treated as locked initial model config.
+func (m *Manager) CaptureModelBaseline() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	content, err := os.ReadFile(m.cfg.OpenClawConfigPath)
+	if err != nil {
+		return fmt.Errorf("read openclaw config for model baseline: %w", err)
+	}
+	parsed, err := parseConfigJSON(content)
+	if err != nil {
+		return fmt.Errorf("parse openclaw config for model baseline: %w", err)
+	}
+
+	return m.setModelBaselineLocked(parsed)
+}
+
+func (m *Manager) setModelBaselineLocked(parsed map[string]any) error {
+	baselines := make([]modelBaselineEntry, 0, len(modelGuardPaths()))
+	for _, path := range modelGuardPaths() {
+		current, exists := nestedValue(parsed, path...)
+		var cloned any
+		if exists {
+			clonedValue, err := cloneJSONValue(current)
+			if err != nil {
+				return fmt.Errorf("clone model baseline at %v: %w", path, err)
+			}
+			cloned = clonedValue
+		}
+		baselines = append(baselines, modelBaselineEntry{
+			path:   append([]string(nil), path...),
+			value:  cloned,
+			exists: exists,
+		})
+	}
+	m.modelBaselines = baselines
+	m.modelBaselineSet = true
+	return nil
+}
+
+// EnforceModelBaseline restores model-related fields to the captured
+// baseline when it has been modified. The returned bool reports whether
+// a restore write happened.
+func (m *Manager) EnforceModelBaseline() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.modelBaselineSet {
+		return false, nil
+	}
+
+	content, err := os.ReadFile(m.cfg.OpenClawConfigPath)
+	if err != nil {
+		return false, fmt.Errorf("read openclaw config for model check: %w", err)
+	}
+	parsed, err := parseConfigJSON(content)
+	if err != nil {
+		return false, fmt.Errorf("parse openclaw config for model check: %w", err)
+	}
+
+	changed := false
+	for _, baseline := range m.modelBaselines {
+		current, exists := nestedValue(parsed, baseline.path...)
+		if exists == baseline.exists && jsonValuesEqual(current, baseline.value) {
+			continue
+		}
+		changed = true
+		if baseline.exists {
+			cloned, err := cloneJSONValue(baseline.value)
+			if err != nil {
+				return false, fmt.Errorf("clone model baseline for restore at %v: %w", baseline.path, err)
+			}
+			setNestedValue(parsed, cloned, baseline.path...)
+			continue
+		}
+		deleteNestedValue(parsed, baseline.path...)
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	rewritten, err := rewriteConfig(parsed)
+	if err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(m.cfg.OpenClawConfigPath, rewritten, 0o600); err != nil {
+		return false, fmt.Errorf("write restored model to openclaw config: %w", err)
+	}
+
+	return true, nil
+}
+
+func nestedValue(root map[string]any, path ...string) (any, bool) {
+	current := any(root)
+	for idx, key := range path {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		next, ok := obj[key]
+		if !ok {
+			return nil, false
+		}
+		if idx == len(path)-1 {
+			return next, true
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func nestedMap(root map[string]any, path ...string) (map[string]any, bool) {
+	current := root
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
+}
+
+func setNestedValue(root map[string]any, value any, path ...string) {
+	if len(path) == 0 {
+		return
+	}
+	parent := root
+	for _, key := range path[:len(path)-1] {
+		parent = ensureObject(parent, key)
+	}
+	parent[path[len(path)-1]] = value
+}
+
+func deleteNestedValue(root map[string]any, path ...string) {
+	if len(path) == 0 {
+		return
+	}
+	parent := root
+	for _, key := range path[:len(path)-1] {
+		next, ok := parent[key].(map[string]any)
+		if !ok {
+			return
+		}
+		parent = next
+	}
+	delete(parent, path[len(path)-1])
+}
+
+func cloneJSONValue(value any) (any, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var cloned any
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		return nil, err
+	}
+	return cloned, nil
+}
+
+func jsonValuesEqual(a, b any) bool {
+	left, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	right, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(left, right)
+}

--- a/openclaw/internal/configmanager/normalizer.go
+++ b/openclaw/internal/configmanager/normalizer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
@@ -20,10 +21,12 @@ func (m *Manager) NormalizeActiveConfig() error {
 	if err != nil {
 		return err
 	}
-	if !changed {
-		return nil
+	if changed {
+		if err := os.WriteFile(m.cfg.OpenClawConfigPath, normalized, 0o600); err != nil {
+			return err
+		}
 	}
-	return os.WriteFile(m.cfg.OpenClawConfigPath, normalized, 0o600)
+	return normalizePluginInstallRegistry(m.cfg)
 }
 
 func normalizeConfigFile(path string, cfg appconfig.Config) ([]byte, bool, error) {
@@ -59,6 +62,44 @@ func normalizeConfigMap(content []byte, cfg appconfig.Config) ([]byte, bool, err
 	if err := applyChannelOverrides(parsed, channelOpts); err != nil {
 		return nil, false, err
 	}
+
+	normalized, err := rewriteConfig(parsed)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalized, !bytes.Equal(content, normalized), nil
+}
+
+func normalizePluginInstallRegistry(cfg appconfig.Config) error {
+	registryPath := filepath.Join(filepath.Dir(cfg.OpenClawConfigPath), "plugins", "installs.json")
+	content, err := os.ReadFile(registryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read openclaw plugin registry: %w", err)
+	}
+
+	normalized, changed, err := normalizePluginInstallRegistryContent(content, cfg)
+	if err != nil {
+		return fmt.Errorf("normalize openclaw plugin registry: %w", err)
+	}
+	if !changed {
+		return nil
+	}
+	return os.WriteFile(registryPath, normalized, 0o600)
+}
+
+func normalizePluginInstallRegistryContent(content []byte, cfg appconfig.Config) ([]byte, bool, error) {
+	parsed, err := parseConfigJSON(content)
+	if err != nil {
+		return nil, false, err
+	}
+	if cfg.InstalledPluginPathPrefix == "" || cfg.OpenClawExtensionsDir == "" {
+		return content, false, nil
+	}
+
+	rewritePluginPathStrings(parsed, cfg.InstalledPluginPathPrefix, cfg.OpenClawExtensionsDir)
 
 	normalized, err := rewriteConfig(parsed)
 	if err != nil {

--- a/openclaw/internal/configmanager/normalizer_test.go
+++ b/openclaw/internal/configmanager/normalizer_test.go
@@ -180,7 +180,13 @@ func TestPluginInstallPathRewritten(t *testing.T) {
 		"plugins": {
 			"installs": {
 				"foo": {
-					"installPath": "/defaults/.openclaw/extensions/foo"
+					"installPath": "/defaults/.openclaw/extensions/foo",
+					"manifestPath": "/defaults/.openclaw/extensions/foo/openclaw.plugin.json",
+					"metadata": {
+						"manifestCandidates": [
+							"/defaults/.openclaw/extensions/foo/openclaw.plugin.json"
+						]
+					}
 				},
 				"bar": {
 					"installPath": "/opt/vendor/bar"
@@ -215,8 +221,88 @@ func TestPluginInstallPathRewritten(t *testing.T) {
 	if got, _ := foo["installPath"].(string); got != wantFoo {
 		t.Fatalf("expected foo installPath to be rewritten to %q, got %q", wantFoo, got)
 	}
+	wantManifest := path.Join(userDir, "foo", "openclaw.plugin.json")
+	if got, _ := foo["manifestPath"].(string); got != wantManifest {
+		t.Fatalf("expected foo manifestPath to be rewritten to %q, got %q", wantManifest, got)
+	}
+	metadata := nestedMapForTest(t, foo, "metadata")
+	candidates, _ := metadata["manifestCandidates"].([]any)
+	if len(candidates) != 1 || candidates[0] != wantManifest {
+		t.Fatalf("expected nested manifest candidates to be rewritten to %q, got %#v", wantManifest, candidates)
+	}
 	if got, _ := bar["installPath"].(string); got != "/opt/vendor/bar" {
 		t.Fatalf("expected bar installPath to be untouched, got %q", got)
+	}
+}
+
+func TestNormalizeActiveConfigRewritesPluginInstallRegistry(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "openclaw.json")
+	registryPath := filepath.Join(root, "plugins", "installs.json")
+	userDir := "/config/.openclaw/extensions"
+
+	config := `{
+    "channels": {},
+    "plugins": {
+        "entries": {}
+    }
+}
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(registryPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registry := `{
+    "installRecords": {
+        "dingtalk-connector": {
+            "installPath": "/defaults/.openclaw/extensions/dingtalk-connector"
+        }
+    },
+    "plugins": [
+        {
+            "pluginId": "dingtalk-connector",
+            "manifestPath": "/defaults/.openclaw/extensions/dingtalk-connector/openclaw.plugin.json",
+            "source": "/defaults/.openclaw/extensions/dingtalk-connector/dist/index.mjs",
+            "rootDir": "/defaults/.openclaw/extensions/dingtalk-connector"
+        }
+    ]
+}
+`
+	if err := os.WriteFile(registryPath, []byte(registry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := New(appconfig.Config{
+		OpenClawConfigPath:           configPath,
+		OpenClawBundledExtensionsDir: t.TempDir(),
+		OpenClawExtensionsDir:        userDir,
+		InstalledPluginPathPrefix:    "/defaults/.openclaw/extensions/",
+	}, nil, nil)
+	if err := manager.NormalizeActiveConfig(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readConfigForTest(t, registryPath)
+	record := nestedMapForTest(t, got, "installRecords", "dingtalk-connector")
+	if gotPath, _ := record["installPath"].(string); gotPath != path.Join(userDir, "dingtalk-connector") {
+		t.Fatalf("expected install registry path to be rewritten, got %q", gotPath)
+	}
+	plugins, _ := got["plugins"].([]any)
+	if len(plugins) != 1 {
+		t.Fatalf("expected one plugin entry, got %#v", plugins)
+	}
+	plugin, _ := plugins[0].(map[string]any)
+	wantRoot := path.Join(userDir, "dingtalk-connector")
+	if gotPath, _ := plugin["rootDir"].(string); gotPath != wantRoot {
+		t.Fatalf("expected rootDir to be rewritten to %q, got %q", wantRoot, gotPath)
+	}
+	if gotPath, _ := plugin["manifestPath"].(string); gotPath != path.Join(wantRoot, "openclaw.plugin.json") {
+		t.Fatalf("expected manifestPath to be rewritten, got %q", gotPath)
+	}
+	if gotPath, _ := plugin["source"].(string); gotPath != path.Join(wantRoot, "dist", "index.mjs") {
+		t.Fatalf("expected source to be rewritten, got %q", gotPath)
 	}
 }
 

--- a/openclaw/internal/httpserver/server.go.451725900058008583
+++ b/openclaw/internal/httpserver/server.go.451725900058008583
@@ -17,8 +17,6 @@ type Server struct {
 	srv *http.Server
 }
 
-const openClawWaitWarmupTimeout = 30 * time.Second
-
 func New(bind string, proc *process.Manager, prof *profiler.Profiler, inspector *openclawinspector.Inspector, st *store.Store) *Server {
 	router := gin.New()
 	router.Use(gin.Recovery())
@@ -60,15 +58,13 @@ func New(bind string, proc *process.Manager, prof *profiler.Profiler, inspector 
 
 	router.GET("/openclaw-wait/ready", func(c *gin.Context) {
 		snapshot := proc.Snapshot()
-		ready := openClawWaitReady(snapshot)
+		ready := snapshot.Status == process.StatusRunning
 		c.JSON(http.StatusOK, gin.H{
-			"ready":                  ready,
-			"status":                 snapshot.Status,
-			"gateway_warmup_started": snapshot.GatewayWarmupStarted,
-			"gateway_warmup_ready":   snapshot.GatewayWarmupReady,
-			"openclaw_pid":           snapshot.PID,
-			"operation":              snapshot.LastOperation,
-			"operation_log":          snapshot.LastOperationResult,
+			"ready":         ready,
+			"status":        snapshot.Status,
+			"openclaw_pid":  snapshot.PID,
+			"operation":     snapshot.LastOperation,
+			"operation_log": snapshot.LastOperationResult,
 		})
 	})
 
@@ -96,10 +92,6 @@ func New(bind string, proc *process.Manager, prof *profiler.Profiler, inspector 
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 	}
-}
-
-func openClawWaitReady(snapshot process.Snapshot) bool {
-	return snapshot.Status == process.StatusRunning || snapshot.GatewayWarmupStarted || snapshot.GatewayWarmupReady
 }
 
 func openClawWaitPage(target string) string {
@@ -138,37 +130,24 @@ func openClawWaitPage(target string) string {
 </head>
 <body>
   <main>
-    <h1>&#27491;&#22312;&#21551;&#21160;&#40857;&#34430;</h1>
-    <p id="status">&#21518;&#21488;&#26381;&#21153;&#20934;&#22791;&#20013;&#65292;&#35831;&#31245;&#20505;&#12290;</p>
+    <h1>正在启动龙虾</h1>
+    <p id="status">后台服务准备中，请稍候。</p>
     <div class="bar"></div>
   </main>
   <script>
     const target = ` + strconv.Quote(target) + `;
-    const warmupWaitMs = ` + strconv.FormatInt(openClawWaitWarmupTimeout.Milliseconds(), 10) + `;
-    let gatewayReadyAt = 0;
     async function check() {
       try {
         const resp = await fetch("/openclaw-wait/ready", { cache: "no-store" });
         const data = await resp.json();
         if (data.ready) {
-          if (gatewayReadyAt === 0) {
-            gatewayReadyAt = Date.now();
-          }
-          const warmupStarted = data.gateway_warmup_started === true;
-          const warmupReady = data.gateway_warmup_ready === true;
-          const warmupTimedOut = (warmupStarted || warmupReady) && Date.now() - gatewayReadyAt >= warmupWaitMs;
-          if (warmupReady || warmupTimedOut) {
-            location.replace(target);
-            return;
-          }
-          document.getElementById("status").textContent = "\u6b63\u5728\u9884\u70ed\u6a21\u578b\u76ee\u5f55\uff0c\u9a6c\u4e0a\u8fdb\u5165\u3002";
-          setTimeout(check, 1000);
+          location.replace(target);
           return;
         }
         const status = data.status || "starting";
-        document.getElementById("status").textContent = "\u5f53\u524d\u72b6\u6001\uff1a" + status;
+        document.getElementById("status").textContent = "当前状态：" + status;
       } catch (_) {
-        document.getElementById("status").textContent = "\u6b63\u5728\u8fde\u63a5\u672c\u5730\u542f\u52a8\u670d\u52a1\u3002";
+        document.getElementById("status").textContent = "正在连接本地启动服务。";
       }
       setTimeout(check, 1200);
     }

--- a/openclaw/internal/httpserver/server_test.go
+++ b/openclaw/internal/httpserver/server_test.go
@@ -1,0 +1,39 @@
+package httpserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/iamlovingit/clawmanager-openclaw-image/internal/process"
+)
+
+func TestOpenClawWaitReadyDoesNotRequireGatewayWarmup(t *testing.T) {
+	if !openClawWaitReady(process.Snapshot{Status: process.StatusRunning, GatewayWarmupReady: false}) {
+		t.Fatal("running gateway should release wait page even while models warmup continues")
+	}
+}
+
+func TestOpenClawWaitReadyDoesNotReleaseStartingGateway(t *testing.T) {
+	if openClawWaitReady(process.Snapshot{Status: process.StatusStarting}) {
+		t.Fatal("starting gateway should not release wait page before gateway readiness promotion")
+	}
+}
+
+func TestOpenClawWaitReadyReleasesWhenWarmupStarted(t *testing.T) {
+	if !openClawWaitReady(process.Snapshot{Status: process.StatusStarting, GatewayWarmupStarted: true}) {
+		t.Fatal("started warmup should release wait page into bounded warmup wait")
+	}
+}
+
+func TestOpenClawWaitPageStartsWarmupTimeoutAfterGatewayReady(t *testing.T) {
+	page := openClawWaitPage("http://localhost:18789")
+	if !strings.Contains(page, "let gatewayReadyAt = 0") {
+		t.Fatal("wait page should track when the gateway first becomes ready")
+	}
+	if !strings.Contains(page, "gatewayReadyAt = Date.now()") {
+		t.Fatal("wait page should start warmup timeout after gateway readiness")
+	}
+	if strings.Contains(page, "const startedAt = Date.now()") {
+		t.Fatal("wait page should not start warmup timeout at page load")
+	}
+}

--- a/openclaw/internal/process/manager.go
+++ b/openclaw/internal/process/manager.go
@@ -2,16 +2,38 @@ package process
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
+)
+
+const (
+	startupNotificationTimeout  = 60 * time.Second
+	startupNotificationInterval = 2 * time.Second
+	startupNotificationCmdWait  = time.Second
+	startupNotificationTTL      = 60 * time.Second
+	desktopNotificationEnvTTL   = 10 * time.Second
+	gatewayReadyPollInterval    = time.Second
+	gatewayReadyHTTPTimeout     = 2 * time.Second
+	gatewayChannelSettleDelay   = 5 * time.Second
+	channelsJSONEnv             = "CLAWMANAGER_OPENCLAW_CHANNELS_JSON"
+	skipChannelsEnv             = "OPENCLAW_SKIP_CHANNELS"
+	gatewayModelsStdoutPath     = "/tmp/gateway-models.json"
+	gatewayModelsStderrPath     = "/tmp/gateway-models.err"
 )
 
 type Status string
@@ -27,33 +49,52 @@ const (
 )
 
 type Snapshot struct {
-	Status              Status        `json:"status"`
-	PID                 int           `json:"pid,omitempty"`
-	StartedAt           time.Time     `json:"started_at,omitempty"`
-	ExitedAt            time.Time     `json:"exited_at,omitempty"`
-	LastExitCode        int           `json:"last_exit_code,omitempty"`
-	LastExitReason      string        `json:"last_exit_reason,omitempty"`
-	LastOperation       string        `json:"last_operation,omitempty"`
-	LastOperationResult string        `json:"last_operation_result,omitempty"`
-	Restarts            int           `json:"restarts"`
-	Uptime              time.Duration `json:"uptime,omitempty"`
+	Status               Status        `json:"status"`
+	PID                  int           `json:"pid,omitempty"`
+	StartedAt            time.Time     `json:"started_at,omitempty"`
+	ExitedAt             time.Time     `json:"exited_at,omitempty"`
+	LastExitCode         int           `json:"last_exit_code,omitempty"`
+	LastExitReason       string        `json:"last_exit_reason,omitempty"`
+	LastOperation        string        `json:"last_operation,omitempty"`
+	LastOperationResult  string        `json:"last_operation_result,omitempty"`
+	GatewayWarmupStarted bool          `json:"gateway_warmup_started"`
+	GatewayWarmupReady   bool          `json:"gateway_warmup_ready"`
+	Restarts             int           `json:"restarts"`
+	Uptime               time.Duration `json:"uptime,omitempty"`
+}
+
+type doctorState struct {
+	Command         []string  `json:"command"`
+	ConfigHash      string    `json:"config_hash"`
+	OpenClawVersion string    `json:"openclaw_version"`
+	SucceededAt     time.Time `json:"succeeded_at"`
 }
 
 type Manager struct {
 	cfg appconfig.Config
 
-	mu                  sync.RWMutex
-	cmd                 *exec.Cmd
-	status              Status
-	startedAt           time.Time
-	exitedAt            time.Time
-	lastExitCode        int
-	lastExitReason      string
-	lastOperation       string
-	lastOperationResult string
-	restarts            int
-	done                chan struct{}
-	stopRequested       bool
+	opMu                   sync.Mutex
+	mu                     sync.RWMutex
+	cmd                    *exec.Cmd
+	status                 Status
+	startedAt              time.Time
+	exitedAt               time.Time
+	lastExitCode           int
+	lastExitReason         string
+	lastOperation          string
+	lastOperationResult    string
+	restarts               int
+	done                   chan struct{}
+	stopRequested          bool
+	notifyMu               sync.Mutex
+	notificationID         string
+	notificationGeneration int
+	notifyEnvMu            sync.Mutex
+	notifyEnvs             [][]string
+	notifyEnvLoadedAt      time.Time
+	warmupMu               sync.Mutex
+	warmupStarted          bool
+	warmupDone             bool
 }
 
 func New(cfg appconfig.Config) *Manager {
@@ -61,28 +102,63 @@ func New(cfg appconfig.Config) *Manager {
 }
 
 func (m *Manager) Start(ctx context.Context) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.opMu.Lock()
+	defer m.opMu.Unlock()
+	return m.start(ctx, false)
+}
 
+func (m *Manager) start(ctx context.Context, skipDoctor bool) error {
+	m.mu.Lock()
 	if m.cmd != nil && m.cmd.Process != nil && m.status != StatusStopped && m.status != StatusCrashed {
 		m.lastOperation = "start_openclaw"
 		m.lastOperationResult = "noop_already_running"
+		m.mu.Unlock()
 		return nil
 	}
 	if len(m.cfg.OpenClawCommand) == 0 {
+		m.mu.Unlock()
 		return errors.New("openclaw command is empty")
 	}
 
+	m.status = StatusStarting
+	m.lastOperation = "start_openclaw"
+	m.lastOperationResult = "preparing_start"
+	m.mu.Unlock()
+
+	m.notifyStartup(ctx, m.cfg.StartupNotificationMessage)
+	doctorRan := false
+	if !skipDoctor && m.shouldRunDoctorBeforeStart() {
+		m.setLastOperationResult("running_openclaw_doctor")
+		m.notifyStartup(ctx, m.cfg.StartupRepairNotificationMessage)
+		if err := m.runDoctor(ctx); err != nil {
+			m.markStartFailed(err)
+			return fmt.Errorf("run openclaw doctor --fix: %w", err)
+		}
+		doctorRan = true
+		if err := m.writeDoctorState(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "openclaw-agent: record doctor state failed: %v\n", err)
+		}
+		m.notifyStartup(ctx, m.cfg.StartupNotificationMessage)
+	}
+
+	m.setLastOperationResult("starting_openclaw_gateway")
 	cmd := exec.CommandContext(context.Background(), m.cfg.OpenClawCommand[0], m.cfg.OpenClawCommand[1:]...)
+	cmd.Env = openClawStartEnvFromOS()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	m.status = StatusStarting
-	m.lastOperation = "start_openclaw"
+	m.mu.Lock()
+	if m.cmd != nil && m.cmd.Process != nil && m.status != StatusStopped && m.status != StatusCrashed {
+		m.lastOperationResult = "noop_already_running"
+		m.mu.Unlock()
+		return nil
+	}
 	if err := cmd.Start(); err != nil {
-		m.status = StatusCrashed
-		m.lastOperationResult = err.Error()
-		m.lastExitReason = err.Error()
+		m.mu.Unlock()
+		if !skipDoctor && !doctorRan && m.doctorPolicy() == "auto" {
+			return m.repairAfterStartFailure(ctx, fmt.Errorf("start openclaw: %w", err))
+		}
+		m.markStartFailed(err)
 		return fmt.Errorf("start openclaw: %w", err)
 	}
 
@@ -93,43 +169,677 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.exitedAt = time.Time{}
 	m.lastExitReason = ""
 	m.lastOperationResult = "started"
+	m.warmupStarted = false
+	m.warmupDone = false
+	pid := cmd.Process.Pid
+	repairOnHealthTimeout := !skipDoctor && !doctorRan && m.doctorPolicy() == "auto"
+	m.mu.Unlock()
 
-	go m.wait(cmd)
-	go m.promoteRunning(cmd.Process.Pid)
+	go m.wait(cmd, repairOnHealthTimeout)
+	go m.promoteRunning(pid, repairOnHealthTimeout)
+	m.startGatewayModelsWarmup(m.done)
 	return nil
 }
 
-func (m *Manager) promoteRunning(pid int) {
+func openClawStartEnvFromOS() []string {
+	raw, present := os.LookupEnv(channelsJSONEnv)
+	return openClawStartEnv(os.Environ(), raw, present)
+}
+
+func openClawStartEnv(base []string, channelsRaw string, channelsPresent bool) []string {
+	env := append([]string(nil), base...)
+	if channelsEnvConfigured(channelsRaw, channelsPresent) {
+		return removeEnv(env, skipChannelsEnv)
+	}
+	return setOrAppend(env, skipChannelsEnv, "1")
+}
+
+func channelsEnvConfigured(raw string, present bool) bool {
+	return present && strings.TrimSpace(raw) != ""
+}
+
+func removeEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := env[:0]
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func (m *Manager) startGatewayModelsWarmup(done <-chan struct{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		if done == nil {
+			return
+		}
+		select {
+		case <-done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	go func() {
+		defer cancel()
+		err := m.runGatewayModelsWarmup(ctx, done)
+		if err == nil {
+			m.markGatewayModelsWarmupDone(done)
+		}
+		if err != nil && !errors.Is(err, context.Canceled) {
+			fmt.Fprintf(os.Stderr, "openclaw-agent: gateway models warmup failed: %v\n", err)
+		}
+	}()
+}
+
+func (m *Manager) markGatewayModelsWarmupStarted(done <-chan struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if done != nil && m.done == done {
+		m.warmupStarted = true
+	}
+}
+
+func (m *Manager) markGatewayModelsWarmupDone(done <-chan struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if done != nil && m.done == done {
+		m.warmupDone = true
+	}
+}
+
+func (m *Manager) runGatewayModelsWarmup(ctx context.Context, done <-chan struct{}) error {
+	m.warmupMu.Lock()
+	defer m.warmupMu.Unlock()
+
+	if err := m.waitForGatewayReady(ctx); err != nil {
+		return err
+	}
+	if delay := gatewayChannelSettleDelayFromOS(); delay > 0 {
+		fmt.Fprintf(os.Stderr, "openclaw-agent: gateway HTTP ready; waiting %s before models warmup\n", delay)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	started := time.Now()
+	m.markGatewayModelsWarmupStarted(done)
+	fmt.Fprintln(os.Stderr, "openclaw-agent: gateway HTTP ready; warming models list")
+	if err := m.runGatewayModelsWarmupOnce(ctx); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "openclaw-agent: gateway models warmup completed in %s\n", time.Since(started).Round(time.Millisecond))
+	return nil
+}
+
+func (m *Manager) runGatewayModelsWarmupOnce(ctx context.Context) error {
+	bin, args := gatewayModelsWarmupCommand(m.cfg)
+	cmd := exec.CommandContext(ctx, bin, args...)
+
+	if err := os.MkdirAll(filepath.Dir(gatewayModelsStdoutPath), 0o755); err != nil {
+		return fmt.Errorf("prepare gateway models stdout dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(gatewayModelsStderrPath), 0o755); err != nil {
+		return fmt.Errorf("prepare gateway models stderr dir: %w", err)
+	}
+
+	stdout, err := os.OpenFile(gatewayModelsStdoutPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open gateway models stdout: %w", err)
+	}
+	defer stdout.Close()
+
+	stderr, err := os.OpenFile(gatewayModelsStderrPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open gateway models stderr: %w", err)
+	}
+	defer stderr.Close()
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) waitForGatewayReady(ctx context.Context) error {
+	readyURL := gatewayReadyURL(m.cfg.OpenClawHealthURL)
+	if readyURL == "" {
+		return nil
+	}
+	client := &http.Client{Timeout: gatewayReadyHTTPTimeout}
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, readyURL, nil)
+		if err == nil {
+			resp, err := client.Do(req)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+					return nil
+				}
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		timer := time.NewTimer(gatewayReadyPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func gatewayReadyURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	parsed.Path = "/readyz"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func gatewayModelsWarmupCommand(cfg appconfig.Config) (string, []string) {
+	return openClawBinary(cfg), []string{
+		"gateway",
+		"call",
+		"models.list",
+		"--params",
+		"{}",
+		"--timeout",
+		"180000",
+		"--json",
+	}
+}
+
+func gatewayChannelSettleDelayFromOS() time.Duration {
+	raw, present := os.LookupEnv(channelsJSONEnv)
+	if channelsEnvConfigured(raw, present) {
+		return gatewayChannelSettleDelay
+	}
+	return 0
+}
+
+func openClawBinary(cfg appconfig.Config) string {
+	if len(cfg.OpenClawCommand) > 0 && cfg.OpenClawCommand[0] != "" {
+		return cfg.OpenClawCommand[0]
+	}
+	return "openclaw"
+}
+
+func (m *Manager) runDoctor(ctx context.Context) error {
+	if len(m.cfg.OpenClawDoctorCommand) == 0 {
+		return nil
+	}
+	command := lowerPriorityCommand(m.cfg.OpenClawDoctorCommand)
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func lowerPriorityCommand(command []string) []string {
+	next := append([]string(nil), command...)
+	if len(next) == 0 {
+		return next
+	}
+	if ionice, err := exec.LookPath("ionice"); err == nil {
+		next = append([]string{ionice, "-c", "3"}, next...)
+	}
+	if nice, err := exec.LookPath("nice"); err == nil {
+		next = append([]string{nice, "-n", "10"}, next...)
+	}
+	return next
+}
+
+func (m *Manager) shouldRunDoctorBeforeStart() bool {
+	switch m.doctorPolicy() {
+	case "always":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) doctorPolicy() string {
+	switch strings.ToLower(strings.TrimSpace(m.cfg.OpenClawDoctorPolicy)) {
+	case "always", "never", "auto":
+		return strings.ToLower(strings.TrimSpace(m.cfg.OpenClawDoctorPolicy))
+	default:
+		return "auto"
+	}
+}
+
+func (m *Manager) writeDoctorState(ctx context.Context) error {
+	state, err := m.buildDoctorState(ctx)
+	if err != nil {
+		return err
+	}
+	state.SucceededAt = time.Now().UTC()
+	if err := os.MkdirAll(m.cfg.AgentDataDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(m.doctorStatePath(), append(data, '\n'), 0o644)
+}
+
+func (m *Manager) buildDoctorState(ctx context.Context) (doctorState, error) {
+	configHash, err := fileSHA256(m.cfg.OpenClawConfigPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return doctorState{}, err
+	}
+	return doctorState{
+		Command:         append([]string(nil), m.cfg.OpenClawDoctorCommand...),
+		ConfigHash:      configHash,
+		OpenClawVersion: m.openClawVersion(ctx),
+	}, nil
+}
+
+func (m *Manager) doctorStatePath() string {
+	return filepath.Join(m.cfg.AgentDataDir, "openclaw-doctor-state.json")
+}
+
+func (m *Manager) openClawVersion(ctx context.Context) string {
+	bin := "openclaw"
+	if len(m.cfg.OpenClawCommand) > 0 && m.cfg.OpenClawCommand[0] != "" {
+		bin = m.cfg.OpenClawCommand[0]
+	} else if len(m.cfg.OpenClawDoctorCommand) > 0 && m.cfg.OpenClawDoctorCommand[0] != "" {
+		bin = m.cfg.OpenClawDoctorCommand[0]
+	}
+
+	versionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(versionCtx, bin, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func fileSHA256(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (m *Manager) notifyStartup(_ context.Context, message string) {
+	if message == "" {
+		return
+	}
+
+	m.notifyMu.Lock()
+	m.notificationGeneration++
+	generation := m.notificationGeneration
+	m.notifyMu.Unlock()
+
+	go m.notifyWithRetry(context.Background(), message, generation)
+}
+
+func (m *Manager) notifyWithRetry(ctx context.Context, message string, generation int) {
+	deadline := time.NewTimer(startupNotificationTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(startupNotificationInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		if !m.isCurrentNotification(generation) {
+			return
+		}
+		if err := m.tryNotifyStartup(ctx, message, generation); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			fmt.Fprintf(os.Stderr, "openclaw-agent: startup notification skipped: %s: %v\n", message, lastErr)
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *Manager) tryNotifyStartup(ctx context.Context, message string, generation int) error {
+	var lastErr error
+	for _, env := range m.desktopNotificationEnvs() {
+		if !m.isCurrentNotification(generation) {
+			return nil
+		}
+		notifyCtx, cancel := context.WithTimeout(ctx, startupNotificationCmdWait)
+		cmd := exec.CommandContext(notifyCtx, "notify-send", m.notifySendArgs(message)...)
+		cmd.Env = env
+		out, err := cmd.Output()
+		cancel()
+		id := strings.TrimSpace(string(out))
+		if err == nil && id != "" && id != "0" {
+			m.storeNotificationID(generation, id)
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = fmt.Errorf("notify-send returned invalid notification id %q", id)
+		}
+	}
+	return lastErr
+}
+
+func (m *Manager) notifySendArgs(message string) []string {
+	args := []string{
+		"-a", "OpenClaw",
+		"-t", fmt.Sprintf("%d", startupNotificationTTL.Milliseconds()),
+		"-h", "boolean:transient:true",
+		"-p",
+	}
+	m.notifyMu.Lock()
+	if m.notificationID != "" {
+		args = append(args, "-r", m.notificationID)
+	}
+	m.notifyMu.Unlock()
+	return append(args, "OpenClaw", message)
+}
+
+func (m *Manager) storeNotificationID(generation int, id string) {
+	if id == "" {
+		return
+	}
+	m.notifyMu.Lock()
+	defer m.notifyMu.Unlock()
+	if m.notificationGeneration == generation {
+		m.notificationID = id
+	}
+}
+
+func (m *Manager) isCurrentNotification(generation int) bool {
+	m.notifyMu.Lock()
+	defer m.notifyMu.Unlock()
+	return m.notificationGeneration == generation
+}
+
+func (m *Manager) desktopNotificationEnvs() [][]string {
+	m.notifyEnvMu.Lock()
+	if len(m.notifyEnvs) > 0 && time.Since(m.notifyEnvLoadedAt) < desktopNotificationEnvTTL {
+		envs := m.notifyEnvs
+		m.notifyEnvMu.Unlock()
+		return envs
+	}
+	m.notifyEnvMu.Unlock()
+
+	envs := buildDesktopNotificationEnvs(m.cfg)
+
+	m.notifyEnvMu.Lock()
+	m.notifyEnvs = envs
+	m.notifyEnvLoadedAt = time.Now()
+	m.notifyEnvMu.Unlock()
+	return envs
+}
+
+func buildDesktopNotificationEnvs(cfg appconfig.Config) [][]string {
+	env := os.Environ()
+	env = setOrAppend(env, "DISPLAY", ":1")
+	env = setOrAppend(env, "HOME", "/config")
+	env = setOrAppend(env, "PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+	env = setOrAppend(env, "XDG_CURRENT_DESKTOP", "KDE")
+	env = setOrAppend(env, "XDG_SESSION_TYPE", "wayland")
+
+	runtimeDir := "/config/.XDG"
+	waylandDisplay := "wayland-0"
+	if cfg.WaylandSocketPath != "" {
+		runtimeDir = filepath.Dir(cfg.WaylandSocketPath)
+		waylandDisplay = filepath.Base(cfg.WaylandSocketPath)
+	}
+	env = setOrAppend(env, "WAYLAND_DISPLAY", waylandDisplay)
+	env = setOrAppend(env, "QT_QPA_PLATFORM", "wayland")
+
+	sessionBusPaths := desktopSessionBusPaths()
+	runtimeDirs := uniqueStrings([]string{
+		os.Getenv("XDG_RUNTIME_DIR"),
+		runtimeDir,
+		"/run/user/1000",
+	})
+	envs := make([][]string, 0, len(sessionBusPaths)+len(runtimeDirs)+1)
+	for _, busPath := range sessionBusPaths {
+		candidate := setOrAppend(env, "XDG_RUNTIME_DIR", runtimeDir)
+		candidate = setOrAppend(candidate, "DBUS_SESSION_BUS_ADDRESS", "unix:path="+busPath)
+		envs = append(envs, candidate)
+	}
+	for _, dir := range runtimeDirs {
+		if dir == "" {
+			continue
+		}
+		candidate := setOrAppend(env, "XDG_RUNTIME_DIR", dir)
+		candidate = setOrAppend(candidate, "DBUS_SESSION_BUS_ADDRESS", "unix:path="+filepath.Join(dir, "bus"))
+		envs = append(envs, candidate)
+	}
+	envs = append(envs, env)
+	return envs
+}
+
+func desktopSessionBusPaths() []string {
+	matches, err := filepath.Glob("/tmp/dbus-*")
+	if err != nil {
+		return nil
+	}
+	type busPath struct {
+		path    string
+		modTime time.Time
+	}
+	paths := make([]busPath, 0, len(matches))
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil || info.IsDir() || info.Mode()&os.ModeSocket == 0 {
+			continue
+		}
+		paths = append(paths, busPath{path: match, modTime: info.ModTime()})
+	}
+	sort.SliceStable(paths, func(i, j int) bool {
+		return paths[i].modTime.Before(paths[j].modTime)
+	})
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, path.path)
+	}
+	return out
+}
+
+func setOrAppend(env []string, key, value string) []string {
+	prefix := key + "="
+	next := append([]string(nil), env...)
+	for i, item := range next {
+		if len(item) >= len(prefix) && item[:len(prefix)] == prefix {
+			next[i] = prefix + value
+			return next
+		}
+	}
+	return append(next, prefix+value)
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func (m *Manager) setLastOperationResult(result string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastOperationResult = result
+}
+
+func (m *Manager) markStartFailed(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.status = StatusCrashed
+	m.lastOperationResult = err.Error()
+	m.lastExitReason = err.Error()
+}
+
+func (m *Manager) promoteRunning(pid int, repairOnHealthTimeout bool) {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
-	timeout := time.NewTimer(30 * time.Second)
+	timeout := time.NewTimer(m.startupHealthTimeout())
 	defer timeout.Stop()
 
 	for {
 		select {
 		case <-timeout.C:
-			m.mu.Lock()
-			if m.cmd != nil && m.cmd.Process != nil && m.cmd.Process.Pid == pid && m.status == StatusStarting {
-				m.status = StatusRunning
-				m.lastOperationResult = "running"
+			if repairOnHealthTimeout && m.cfg.OpenClawHealthURL != "" {
+				go m.repairAfterStartupHealthTimeout(pid)
+				return
 			}
-			m.mu.Unlock()
+			m.markRunning(pid, "running")
 			return
 		case <-ticker.C:
 			if m.checkHealth() {
-				m.mu.Lock()
-				if m.cmd != nil && m.cmd.Process != nil && m.cmd.Process.Pid == pid && m.status == StatusStarting {
-					m.status = StatusRunning
-					m.lastOperationResult = "running"
-				}
-				m.mu.Unlock()
+				m.markRunning(pid, "running")
 				return
 			}
 		}
 	}
 }
 
+func (m *Manager) startupHealthTimeout() time.Duration {
+	if m.cfg.OpenClawStartupHealthTimeout > 0 {
+		return m.cfg.OpenClawStartupHealthTimeout
+	}
+	return 90 * time.Second
+}
+
+func (m *Manager) markRunning(pid int, result string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cmd != nil && m.cmd.Process != nil && m.cmd.Process.Pid == pid && m.status == StatusStarting {
+		m.status = StatusRunning
+		m.lastOperationResult = result
+	}
+}
+
+func (m *Manager) repairAfterStartupHealthTimeout(pid int) {
+	m.opMu.Lock()
+	defer m.opMu.Unlock()
+
+	m.mu.Lock()
+	if m.cmd == nil || m.cmd.Process == nil || m.cmd.Process.Pid != pid || m.status != StatusStarting {
+		m.mu.Unlock()
+		return
+	}
+	m.lastOperationResult = "repairing_after_health_timeout"
+	m.mu.Unlock()
+
+	m.notifyStartup(context.Background(), m.cfg.StartupRepairNotificationMessage)
+
+	repairCtx, cancel := context.WithTimeout(context.Background(), m.cfg.ProcessStopTimeout+3*time.Minute)
+	defer cancel()
+	if err := m.stop(repairCtx); err != nil {
+		m.markStartFailed(fmt.Errorf("stop unhealthy openclaw before doctor: %w", err))
+		return
+	}
+	if err := m.runDoctor(repairCtx); err != nil {
+		m.markStartFailed(fmt.Errorf("run openclaw doctor --fix after health timeout: %w", err))
+		return
+	}
+	if err := m.writeDoctorState(repairCtx); err != nil {
+		fmt.Fprintf(os.Stderr, "openclaw-agent: record doctor state failed: %v\n", err)
+	}
+	if err := m.start(context.Background(), true); err != nil {
+		m.markStartFailed(err)
+	}
+}
+
+func (m *Manager) repairAfterStartFailure(ctx context.Context, startErr error) error {
+	m.setLastOperationResult("repairing_after_start_failure")
+	m.notifyStartup(ctx, m.cfg.StartupRepairNotificationMessage)
+
+	repairCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	if err := m.runDoctor(repairCtx); err != nil {
+		wrapped := fmt.Errorf("%w; doctor after start failure also failed: %v", startErr, err)
+		m.markStartFailed(wrapped)
+		return wrapped
+	}
+	if err := m.writeDoctorState(repairCtx); err != nil {
+		fmt.Fprintf(os.Stderr, "openclaw-agent: record doctor state failed: %v\n", err)
+	}
+	return m.start(context.Background(), true)
+}
+
+func (m *Manager) repairAfterStartupExit(pid int, exitReason string) {
+	m.opMu.Lock()
+	defer m.opMu.Unlock()
+
+	m.mu.RLock()
+	if m.cmd != nil || (m.status != StatusCrashed && m.status != StatusStopped) || m.lastExitReason != exitReason {
+		m.mu.RUnlock()
+		return
+	}
+	m.mu.RUnlock()
+
+	m.setLastOperationResult("repairing_after_startup_exit")
+	m.notifyStartup(context.Background(), m.cfg.StartupRepairNotificationMessage)
+
+	repairCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if err := m.runDoctor(repairCtx); err != nil {
+		m.markStartFailed(fmt.Errorf("run openclaw doctor --fix after startup exit pid=%d: %w", pid, err))
+		return
+	}
+	if err := m.writeDoctorState(repairCtx); err != nil {
+		fmt.Fprintf(os.Stderr, "openclaw-agent: record doctor state failed: %v\n", err)
+	}
+	if err := m.start(context.Background(), true); err != nil {
+		m.markStartFailed(err)
+	}
+}
+
 func (m *Manager) Stop(ctx context.Context) error {
+	m.opMu.Lock()
+	defer m.opMu.Unlock()
+	return m.stop(ctx)
+}
+
+func (m *Manager) stop(ctx context.Context) error {
 	m.mu.Lock()
 	cmd := m.cmd
 	done := m.done
@@ -188,10 +898,12 @@ func (m *Manager) Stop(ctx context.Context) error {
 }
 
 func (m *Manager) Restart(ctx context.Context) error {
-	if err := m.Stop(ctx); err != nil {
+	m.opMu.Lock()
+	defer m.opMu.Unlock()
+	if err := m.stop(ctx); err != nil {
 		return err
 	}
-	return m.Start(ctx)
+	return m.start(ctx, true)
 }
 
 func (m *Manager) MarkConfiguring() {
@@ -204,14 +916,16 @@ func (m *Manager) Snapshot() Snapshot {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	s := Snapshot{
-		Status:              m.status,
-		StartedAt:           m.startedAt,
-		ExitedAt:            m.exitedAt,
-		LastExitCode:        m.lastExitCode,
-		LastExitReason:      m.lastExitReason,
-		LastOperation:       m.lastOperation,
-		LastOperationResult: m.lastOperationResult,
-		Restarts:            m.restarts,
+		Status:               m.status,
+		StartedAt:            m.startedAt,
+		ExitedAt:             m.exitedAt,
+		LastExitCode:         m.lastExitCode,
+		LastExitReason:       m.lastExitReason,
+		LastOperation:        m.lastOperation,
+		LastOperationResult:  m.lastOperationResult,
+		GatewayWarmupStarted: m.warmupStarted,
+		GatewayWarmupReady:   m.warmupDone,
+		Restarts:             m.restarts,
 	}
 	if m.cmd != nil && m.cmd.Process != nil {
 		s.PID = m.cmd.Process.Pid
@@ -223,10 +937,11 @@ func (m *Manager) Snapshot() Snapshot {
 }
 
 func (m *Manager) checkHealth() bool {
-	if m.cfg.OpenClawHealthURL == "" {
+	readyURL := gatewayReadyURL(m.cfg.OpenClawHealthURL)
+	if readyURL == "" {
 		return true
 	}
-	req, err := http.NewRequest(http.MethodGet, m.cfg.OpenClawHealthURL, nil)
+	req, err := http.NewRequest(http.MethodGet, readyURL, nil)
 	if err != nil {
 		return false
 	}
@@ -239,18 +954,12 @@ func (m *Manager) checkHealth() bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
-func (m *Manager) wait(cmd *exec.Cmd) {
+func (m *Manager) wait(cmd *exec.Cmd, repairOnStartupExit bool) {
 	err := cmd.Wait()
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	defer func() {
-		if m.done != nil {
-			close(m.done)
-			m.done = nil
-		}
-	}()
 
+	wasStarting := m.status == StatusStarting
 	m.exitedAt = time.Now().UTC()
 	if cmd.ProcessState != nil {
 		m.lastExitCode = cmd.ProcessState.ExitCode()
@@ -265,6 +974,8 @@ func (m *Manager) wait(cmd *exec.Cmd) {
 		m.status = StatusStopped
 		m.lastExitReason = "process_exited"
 	}
+	exitReason := m.lastExitReason
+	shouldRepair := repairOnStartupExit && wasStarting && !m.stopRequested && m.doctorPolicy() == "auto"
 	if m.startedAt.Add(30 * time.Second).Before(m.exitedAt) {
 		m.restarts = 0
 	} else {
@@ -272,4 +983,13 @@ func (m *Manager) wait(cmd *exec.Cmd) {
 	}
 	m.cmd = nil
 	m.stopRequested = false
+	if m.done != nil {
+		close(m.done)
+		m.done = nil
+	}
+	m.mu.Unlock()
+
+	if shouldRepair {
+		go m.repairAfterStartupExit(cmd.Process.Pid, exitReason)
+	}
 }

--- a/openclaw/internal/process/manager_test.go
+++ b/openclaw/internal/process/manager_test.go
@@ -1,0 +1,84 @@
+package process
+
+import (
+	"reflect"
+	"testing"
+
+	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
+)
+
+func TestOpenClawStartEnvSkipsChannelsWhenChannelsEnvMissing(t *testing.T) {
+	env := openClawStartEnv([]string{"PATH=/usr/bin"}, "", false)
+
+	if got := envValue(env, skipChannelsEnv); got != "1" {
+		t.Fatalf("expected %s=1 when %s is missing, got %q", skipChannelsEnv, channelsJSONEnv, got)
+	}
+}
+
+func TestOpenClawStartEnvSkipsChannelsWhenChannelsEnvBlank(t *testing.T) {
+	env := openClawStartEnv([]string{"PATH=/usr/bin", skipChannelsEnv + "=0"}, "  \t\n", true)
+
+	if got := envValue(env, skipChannelsEnv); got != "1" {
+		t.Fatalf("expected blank %s to force %s=1, got %q", channelsJSONEnv, skipChannelsEnv, got)
+	}
+}
+
+func TestOpenClawStartEnvDoesNotSkipChannelsWhenChannelsEnvPresent(t *testing.T) {
+	env := openClawStartEnv([]string{"PATH=/usr/bin", skipChannelsEnv + "=1"}, `{"dingtalk":{"enabled":true}}`, true)
+
+	if got := envValue(env, skipChannelsEnv); got != "" {
+		t.Fatalf("expected %s to be absent when %s is present, got %q", skipChannelsEnv, channelsJSONEnv, got)
+	}
+}
+
+func TestGatewayModelsWarmupCommand(t *testing.T) {
+	bin, args := gatewayModelsWarmupCommand(appconfig.Config{
+		OpenClawCommand: []string{"/usr/local/bin/openclaw", "gateway", "run"},
+	})
+
+	if bin != "/usr/local/bin/openclaw" {
+		t.Fatalf("expected warmup to use configured openclaw binary, got %q", bin)
+	}
+	want := []string{"gateway", "call", "models.list", "--params", "{}", "--timeout", "180000", "--json"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("unexpected warmup args:\nwant %#v\n got %#v", want, args)
+	}
+}
+
+func TestGatewayReadyURL(t *testing.T) {
+	tests := map[string]string{
+		"http://127.0.0.1:18789/health":            "http://127.0.0.1:18789/readyz",
+		"http://localhost:18789/health?check=true": "http://localhost:18789/readyz",
+		"https://gateway.example/health":           "https://gateway.example/readyz",
+		"":                                         "",
+		"://bad":                                   "",
+	}
+
+	for input, want := range tests {
+		if got := gatewayReadyURL(input); got != want {
+			t.Fatalf("gatewayReadyURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestGatewayChannelSettleDelayFromOS(t *testing.T) {
+	t.Setenv(channelsJSONEnv, "")
+	if got := gatewayChannelSettleDelayFromOS(); got != 0 {
+		t.Fatalf("blank channels env settle delay = %s, want 0", got)
+	}
+
+	t.Setenv(channelsJSONEnv, `{"dingtalk":{"enabled":true}}`)
+	if got := gatewayChannelSettleDelayFromOS(); got != gatewayChannelSettleDelay {
+		t.Fatalf("configured channels env settle delay = %s, want %s", got, gatewayChannelSettleDelay)
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if len(item) >= len(prefix) && item[:len(prefix)] == prefix {
+			return item[len(prefix):]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
This is a major update enabling OpenClaw agent to run natively inside linuxserver/webtop:ubuntu-kde containers.
- Add browser/launcher package: wait for Wayland socket, then auto-open  Chromium to the OpenClaw UI, working around the broken XDG autostart  in webtop KDE images (no ksmserver / systemd user session)
- Add /openclaw-wait and /openclaw-wait/ready endpoints with an animated  loading page that polls gateway warmup and redirects when ready, giving  users a smooth startup experience inside the desktop environment
- Track GatewayWarmupStarted / GatewayWarmupReady in process.Snapshot;  implement gateway model warmup detection in process.Manager
- Add bootstrap/dingtalk_symlink.go: symlink dingtalk-connector's  node_modules/openclaw to the global install so the plugin resolves
  the package correctly in the container image
- Add rlimit_linux.go / rlimit_other.go to raise open-file limits before  privilege drop, required for stable operation under webtop workloads
- Update Dockerfile, config, and README for webtop deployment