### PR TITLE
fix: ship unified wrapped-chromium for OpenClaw and Hermes webtop images

### DIFF
--- a/hermes/Dockerfile
+++ b/hermes/Dockerfile
@@ -119,6 +119,7 @@ RUN set -eux; \
     chmod -R a+rX /usr/local/lib/hermes-agent/plugins/platforms/redis_team; \
     rm -rf /tmp/hermes-vendor-plugins; \
     sed -i 's/\r$//' \
+        /usr/local/bin/wrapped-chromium \
         /usr/local/bin/hermes-apply-runtime-config \
         /usr/local/bin/start-hermes-terminal \
         /usr/local/bin/start-hermes-gateway \
@@ -126,6 +127,7 @@ RUN set -eux; \
         /etc/s6-overlay/s6-rc.d/hermes-agent/run \
         /etc/s6-overlay/s6-rc.d/hermes-gateway/run; \
     chmod 755 \
+        /usr/local/bin/wrapped-chromium \
         /usr/local/bin/hermes-agent \
         /usr/local/bin/hermes-apply-runtime-config \
         /usr/local/bin/start-hermes-terminal \

--- a/hermes/rootfs/usr/local/bin/wrapped-chromium
+++ b/hermes/rootfs/usr/local/bin/wrapped-chromium
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+BIN="${CHROMIUM_BIN:-/usr/bin/chromium}"
+
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-0}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/config/.XDG}"
+export DISPLAY="${DISPLAY:-:1}"
+
+if ! pgrep -x chromium >/dev/null 2>&1 && [ -n "${HOME:-}" ]; then
+  rm -f "$HOME"/.config/chromium/Singleton* 2>/dev/null || true
+fi
+
+has_setuid_sandbox() {
+  [ -u /usr/lib/chromium/chrome-sandbox ] && [ -x /usr/lib/chromium/chrome-sandbox ]
+}
+
+can_userns_sandbox() {
+  unshare --user --map-root-user true >/dev/null 2>&1
+}
+
+if has_setuid_sandbox || can_userns_sandbox; then
+  exec "$BIN" --password-store=basic --ozone-platform=wayland "$@"
+fi
+
+exec "$BIN" \
+  --password-store=basic \
+  --no-sandbox \
+  --test-type \
+  --disable-gpu \
+  --ozone-platform=wayland \
+  "$@"

--- a/openclaw/Dockerfile.openclaw
+++ b/openclaw/Dockerfile.openclaw
@@ -40,6 +40,7 @@ COPY defaults-template/.config /defaults/.config
 COPY defaults-template/.openclaw /defaults/.openclaw
 COPY config/openclaw-agent /defaults/openclaw-agent
 COPY --from=agent-builder /out/openclaw-agent /usr/local/bin/openclaw-agent
+COPY scripts/wrapped-chromium /usr/local/bin/wrapped-chromium
 COPY scripts/openclaw-agent-run /etc/services.d/openclaw-agent/run
 COPY scripts/openclaw-agent-finish /etc/services.d/openclaw-agent/finish
 
@@ -47,9 +48,11 @@ COPY scripts/openclaw-agent-finish /etc/services.d/openclaw-agent/finish
 # agent's first startup reconciliation.
 RUN sed -i 's/\r$//' /etc/services.d/openclaw-agent/run \
   && sed -i 's/\r$//' /etc/services.d/openclaw-agent/finish \
+  && sed -i 's/\r$//' /usr/local/bin/wrapped-chromium \
   && chmod +x /etc/services.d/openclaw-agent/run \
   && chmod +x /etc/services.d/openclaw-agent/finish \
   && chmod +x /usr/local/bin/openclaw-agent \
+  && chmod +x /usr/local/bin/wrapped-chromium \
   && HOME=/defaults openclaw plugins install /tmp/openclaw-redis-team.tgz \
   && HOME=/defaults openclaw plugins install @dingtalk-real-ai/dingtalk-connector \
   && rm -f /tmp/openclaw-redis-team.tgz \

--- a/openclaw/config/openclaw-agent/config.yaml
+++ b/openclaw/config/openclaw-agent/config.yaml
@@ -31,3 +31,4 @@ process_stop_timeout: 20s
 skill_incremental_interval: 30s
 skill_full_sync_interval: 12h
 max_auto_restart: 3
+browser_executable: /usr/local/bin/wrapped-chromium

--- a/openclaw/internal/config/config.go
+++ b/openclaw/internal/config/config.go
@@ -99,7 +99,7 @@ func Load() (Config, error) {
 		InstalledPluginPathPrefix:        "/defaults/.openclaw/extensions/",
 		DropUserName:                     "abc",
 		BrowserAutoLaunchEnabled:         true,
-		BrowserExecutable:                "/usr/bin/chromium",
+		BrowserExecutable:                "/usr/local/bin/wrapped-chromium",
 		BrowserURL:                       "http://localhost:18789",
 		WaylandSocketPath:                "/config/.XDG/wayland-0",
 		BrowserLaunchWaylandTimeoutRaw:   "60s",

--- a/openclaw/internal/config/config_test.go
+++ b/openclaw/internal/config/config_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDefaultsToWrappedChromium(t *testing.T) {
+	t.Setenv("OPENCLAW_AGENT_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("OPENCLAW_AGENT_INSTANCE_ID", "test-instance")
+	t.Setenv("OPENCLAW_AGENT_BOOTSTRAP_TOKEN", "test-token")
+	t.Setenv("OPENCLAW_AGENT_CONTROL_PLANE_BASE_URL", "http://control-plane.test")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.BrowserExecutable != "/usr/local/bin/wrapped-chromium" {
+		t.Fatalf("BrowserExecutable = %q, want wrapped chromium", cfg.BrowserExecutable)
+	}
+}

--- a/openclaw/scripts/wrapped-chromium
+++ b/openclaw/scripts/wrapped-chromium
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+BIN="${CHROMIUM_BIN:-/usr/bin/chromium}"
+
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-0}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/config/.XDG}"
+export DISPLAY="${DISPLAY:-:1}"
+
+if ! pgrep -x chromium >/dev/null 2>&1 && [ -n "${HOME:-}" ]; then
+  rm -f "$HOME"/.config/chromium/Singleton* 2>/dev/null || true
+fi
+
+has_setuid_sandbox() {
+  [ -u /usr/lib/chromium/chrome-sandbox ] && [ -x /usr/lib/chromium/chrome-sandbox ]
+}
+
+can_userns_sandbox() {
+  unshare --user --map-root-user true >/dev/null 2>&1
+}
+
+if has_setuid_sandbox || can_userns_sandbox; then
+  exec "$BIN" --password-store=basic --ozone-platform=wayland "$@"
+fi
+
+exec "$BIN" \
+  --password-store=basic \
+  --no-sandbox \
+  --test-type \
+  --disable-gpu \
+  --ozone-platform=wayland \
+  "$@"


### PR DESCRIPTION
Replace the webtop Seccomp-only launcher with a wrapper that probes setuid sandbox and user-namespace support at runtime, falling back to --no-sandbox with Wayland/GPU flags when Chromium cannot sandbox inside Docker/K8s nodes (e.g. AppArmor-restricted userns).
- Add shared wrapped-chromium script and bake it into OpenClaw and Hermes images
- Point openclaw-agent browser auto-launch at /usr/local/bin/wrapped-chromium
- Strip CRLF and chmod the wrapper during image build
- Add config default test for wrapped browser executable