### PR TITLE
feat(clawmanager-agent): Pro instance 优先与嵌套 Skill 同步

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 AGENT.md
 .tmp/
+runtimeagent/
+clawmanager-agent/clawmanager-agent-linux
+.tmp-openclaw-patch.json

--- a/clawmanager-agent/cmd/clawmanager-agent/main.go
+++ b/clawmanager-agent/cmd/clawmanager-agent/main.go
@@ -58,20 +58,48 @@ func main() {
 }
 
 func selectMode() agentMode {
-	if runtimeagent.RuntimeAgentModeEnabled() {
+	instanceRequested := instanceAgentRequested()
+	// Lite runtime-pod only when Pro instance credentials are not present.
+	if runtimeagent.RuntimeAgentModeEnabled() && !instanceRequested {
 		return modeRuntimePod
 	}
-	if strings.EqualFold(os.Getenv("CLAWMANAGER_AGENT_ENABLED"), "true") && strings.EqualFold(instanceRuntimeType(), "hermes") {
+	if instanceRequested && hermesInstanceAllowed() {
 		return modeInstance
 	}
 	return modeDisabled
 }
 
-func instanceRuntimeType() string {
-	for _, key := range []string{"CLAWMANAGER_RUNTIME_TYPE", "CLAWMANAGER_AGENT_RUNTIME_TYPE"} {
-		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-			return value
+func instanceAgentRequested() bool {
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv("CLAWMANAGER_AGENT_ENABLED")), "true") {
+		return false
+	}
+	if strings.TrimSpace(os.Getenv("CLAWMANAGER_AGENT_INSTANCE_ID")) == "" {
+		return false
+	}
+	if strings.TrimSpace(os.Getenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN")) == "" {
+		return false
+	}
+	return true
+}
+
+// hermesInstanceAllowed decides whether this Hermes-shipped binary should run
+// the Pro instance agent. ClawManager uses CLAWMANAGER_RUNTIME_TYPE=desktop|gateway
+// as a backend marker; that must not reject Pro instance mode.
+func hermesInstanceAllowed() bool {
+	product := strings.ToLower(strings.TrimSpace(os.Getenv("CLAWMANAGER_AGENT_RUNTIME_TYPE")))
+	if product == "" {
+		backend := strings.ToLower(strings.TrimSpace(os.Getenv("CLAWMANAGER_RUNTIME_TYPE")))
+		switch backend {
+		case "desktop", "gateway":
+			// Backend-only markers from ClawManager; ignore as product type.
+			product = ""
+		default:
+			product = backend
 		}
 	}
-	return ""
+	if product == "" {
+		// Credentials alone are enough inside the Hermes image (doc: Pro instance agent).
+		return true
+	}
+	return product == "hermes"
 }

--- a/clawmanager-agent/cmd/clawmanager-agent/main_test.go
+++ b/clawmanager-agent/cmd/clawmanager-agent/main_test.go
@@ -4,8 +4,11 @@ import "testing"
 
 func TestSelectModePrefersRuntimePodAgent(t *testing.T) {
 	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "control")
-	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "true")
+	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "")
 	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "hermes")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "")
 
 	if got := selectMode(); got != modeRuntimePod {
 		t.Fatalf("selectMode() = %s, want %s", got, modeRuntimePod)
@@ -13,8 +16,13 @@ func TestSelectModePrefersRuntimePodAgent(t *testing.T) {
 }
 
 func TestSelectModeUsesInstanceAgentWhenEnabled(t *testing.T) {
+	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "")
+	t.Setenv("RUNTIME_AGENT_REPORT_TOKEN", "")
 	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "true")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "4")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "boot")
 	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "hermes")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "")
 
 	if got := selectMode(); got != modeInstance {
 		t.Fatalf("selectMode() = %s, want %s", got, modeInstance)
@@ -22,16 +30,71 @@ func TestSelectModeUsesInstanceAgentWhenEnabled(t *testing.T) {
 }
 
 func TestSelectModeDisabledWithoutRuntimeTokens(t *testing.T) {
+	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "")
+	t.Setenv("RUNTIME_AGENT_REPORT_TOKEN", "")
+	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "")
+	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "")
+
 	if got := selectMode(); got != modeDisabled {
 		t.Fatalf("selectMode() = %s, want %s", got, modeDisabled)
 	}
 }
 
 func TestSelectModeDoesNotRunInstanceAgentForOtherRuntime(t *testing.T) {
+	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "")
+	t.Setenv("RUNTIME_AGENT_REPORT_TOKEN", "")
 	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "true")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "4")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "boot")
 	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "openclaw")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "openclaw")
 
 	if got := selectMode(); got != modeDisabled {
 		t.Fatalf("selectMode() = %s, want %s", got, modeDisabled)
+	}
+}
+
+func TestSelectModeUsesAgentRuntimeTypeOverDesktopBackend(t *testing.T) {
+	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "")
+	t.Setenv("RUNTIME_AGENT_REPORT_TOKEN", "")
+	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "true")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "4")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "boot")
+	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "desktop")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "hermes")
+
+	if got := selectMode(); got != modeInstance {
+		t.Fatalf("selectMode() = %s, want %s", got, modeInstance)
+	}
+}
+
+func TestSelectModeDesktopBackendWithoutAgentRuntimeType(t *testing.T) {
+	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "")
+	t.Setenv("RUNTIME_AGENT_REPORT_TOKEN", "")
+	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "true")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "4")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "boot")
+	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "desktop")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "")
+
+	if got := selectMode(); got != modeInstance {
+		t.Fatalf("selectMode() = %s, want %s", got, modeInstance)
+	}
+}
+
+func TestSelectModePrefersInstanceWhenLiteTokensAlsoPresent(t *testing.T) {
+	t.Setenv("RUNTIME_AGENT_CONTROL_TOKEN", "control")
+	t.Setenv("RUNTIME_AGENT_REPORT_TOKEN", "report")
+	t.Setenv("CLAWMANAGER_AGENT_ENABLED", "true")
+	t.Setenv("CLAWMANAGER_AGENT_INSTANCE_ID", "4")
+	t.Setenv("CLAWMANAGER_AGENT_BOOTSTRAP_TOKEN", "boot")
+	t.Setenv("CLAWMANAGER_RUNTIME_TYPE", "desktop")
+	t.Setenv("CLAWMANAGER_AGENT_RUNTIME_TYPE", "hermes")
+
+	if got := selectMode(); got != modeInstance {
+		t.Fatalf("selectMode() = %s, want %s", got, modeInstance)
 	}
 }

--- a/clawmanager-agent/internal/agent/agent.go
+++ b/clawmanager-agent/internal/agent/agent.go
@@ -98,6 +98,17 @@ func (a *Agent) ReportHeartbeat(ctx context.Context, payload gateway.HeartbeatPa
 	return a.reporter.ReportHeartbeat(ctx, payload)
 }
 
+func (a *Agent) ReportSkills(ctx context.Context, payload gateway.SkillReportPayload) error {
+	if payload.PodID == 0 {
+		payload.PodID = a.currentPodID()
+	}
+	return a.reporter.ReportSkills(ctx, payload)
+}
+
+func (a *Agent) PodID() int {
+	return a.currentPodID()
+}
+
 func (a *Agent) registerUntilReady(ctx context.Context) error {
 	for {
 		podID, err := a.reporter.Register(ctx, a.manager.RegisterPayload())

--- a/clawmanager-agent/internal/control/server.go
+++ b/clawmanager-agent/internal/control/server.go
@@ -99,6 +99,46 @@ func NewControlHandler(cfg gateway.Config, manager *gateway.GatewayManager, repo
 		writeJSON(w, http.StatusOK, map[string]bool{"draining": manager.Draining()})
 	})
 
+	mux.HandleFunc("/v1/skills/resync", func(w http.ResponseWriter, r *http.Request) {
+		if !authorizeControl(cfg, w, r) {
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			InstanceID int    `json:"instance_id"`
+			Mode       string `json:"mode"`
+			Trigger    string `json:"trigger"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && r.ContentLength != 0 {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		skillsReporter, ok := reporter.(gateway.SkillsReporter)
+		if !ok || skillsReporter == nil {
+			http.Error(w, "skills reporter unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		mode := strings.TrimSpace(req.Mode)
+		if mode == "" {
+			mode = "full"
+		}
+		payload := gateway.BuildSkillReportPayloadForInstance(cfg, manager, skillsReporter.PodID(), mode, req.InstanceID)
+		if err := skillsReporter.ReportSkills(r.Context(), payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"ok":          true,
+			"mode":        mode,
+			"trigger":     strings.TrimSpace(req.Trigger),
+			"instance_id": req.InstanceID,
+			"instances":   len(payload.Instances),
+		})
+	})
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mux.ServeHTTP(noRedirectResponseWriter{ResponseWriter: w}, r)
 	})

--- a/clawmanager-agent/internal/control/server_test.go
+++ b/clawmanager-agent/internal/control/server_test.go
@@ -83,6 +83,39 @@ func TestControlHandlerCreatesIdempotentGatewayAndRejectsNoFreePort(t *testing.T
 	})
 }
 
+func TestControlHandlerSkillsResyncReportsInventory(t *testing.T) {
+	cfg := testConfig(t)
+	reporter := &fakeReporter{podID: 42}
+	mgr := NewGatewayManager(cfg, &fakeStarter{nextPID: 4242}, NewPortAllocator(func(int) bool { return false }))
+	srv := httptest.NewServer(NewControlHandler(cfg, mgr, reporter))
+	defer srv.Close()
+
+	body := bytes.NewBufferString(`{"instance_id":12,"mode":"full","trigger":"manual"}`)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/skills/resync", body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set(ControlTokenHeader, cfg.ControlToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /v1/skills/resync error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if reporter.skillsCalls != 1 {
+		t.Fatalf("skillsCalls = %d, want 1", reporter.skillsCalls)
+	}
+	if reporter.lastSkills.PodID != 42 || reporter.lastSkills.Mode != "full" {
+		t.Fatalf("skills payload = %+v", reporter.lastSkills)
+	}
+	if len(reporter.lastSkills.Instances) != 1 || reporter.lastSkills.Instances[0].InstanceID != 12 {
+		t.Fatalf("instances = %#v, want empty report for instance 12", reporter.lastSkills.Instances)
+	}
+}
+
 func TestDrainRejectsNewGatewaysAndReportsHeartbeat(t *testing.T) {
 	cfg := testConfig(t)
 	reporter := &fakeReporter{}
@@ -240,11 +273,28 @@ func (f *fakeStarter) startedSpec(index int) GatewayStartSpec {
 
 type fakeReporter struct {
 	lastHeartbeat HeartbeatPayload
+	lastSkills    SkillReportPayload
+	skillsCalls   int
+	skillsErr     error
+	podID         int
 }
 
 func (f *fakeReporter) ReportHeartbeat(_ context.Context, payload HeartbeatPayload) error {
 	f.lastHeartbeat = payload
 	return nil
+}
+
+func (f *fakeReporter) ReportSkills(_ context.Context, payload SkillReportPayload) error {
+	f.skillsCalls++
+	f.lastSkills = payload
+	return f.skillsErr
+}
+
+func (f *fakeReporter) PodID() int {
+	if f.podID != 0 {
+		return f.podID
+	}
+	return 9
 }
 
 func TestCreateGatewayWritesConfigPassesTokenAndDoesNotReportRunningWhenOriginProbeFails(t *testing.T) {

--- a/clawmanager-agent/internal/control/test_aliases_test.go
+++ b/clawmanager-agent/internal/control/test_aliases_test.go
@@ -9,6 +9,7 @@ type GatewayStartSpec = gateway.GatewayStartSpec
 type HeartbeatPayload = gateway.HeartbeatPayload
 type ManagedProcess = gateway.ManagedProcess
 type PortRange = gateway.PortRange
+type SkillReportPayload = gateway.SkillReportPayload
 
 var NewGatewayManager = gateway.NewGatewayManager
 var NewPortAllocator = gateway.NewPortAllocator

--- a/clawmanager-agent/internal/gateway/skills.go
+++ b/clawmanager-agent/internal/gateway/skills.go
@@ -11,14 +11,38 @@ import (
 	"time"
 )
 
+const skillDiscoveryMaxDepth = 2
+
+type skillDiscovery struct {
+	RelativePath string
+	SkillRoot    string
+}
+
 func BuildSkillReportPayload(cfg Config, manager *GatewayManager, podID int, mode string) SkillReportPayload {
+	return BuildSkillReportPayloadForInstance(cfg, manager, podID, mode, 0)
+}
+
+func BuildSkillReportPayloadForInstance(cfg Config, manager *GatewayManager, podID int, mode string, instanceID int) SkillReportPayload {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		mode = "full"
+	}
 	states := manager.GatewayStates()
 	instances := make([]SkillInstanceReport, 0, len(states))
 	for _, state := range states {
+		if instanceID > 0 && state.InstanceID != instanceID {
+			continue
+		}
 		instances = append(instances, SkillInstanceReport{
 			InstanceID:    state.InstanceID,
 			WorkspacePath: state.WorkspacePath,
 			Skills:        scanWorkspaceSkills(state.WorkspacePath),
+		})
+	}
+	if instanceID > 0 && len(instances) == 0 {
+		instances = append(instances, SkillInstanceReport{
+			InstanceID: instanceID,
+			Skills:     []SkillRecord{},
 		})
 	}
 	return SkillReportPayload{
@@ -42,20 +66,13 @@ func scanWorkspaceSkills(workspacePath string) []SkillRecord {
 	seen := map[string]bool{}
 	var skills []SkillRecord
 	for _, root := range roots {
-		entries, err := os.ReadDir(root)
-		if err != nil {
-			continue
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
+		discoveries := discoverSkillDirs(root, skillDiscoveryMaxDepth)
+		for _, discovery := range discoveries {
+			if seen[discovery.SkillRoot] {
 				continue
 			}
-			installPath := filepath.Join(root, entry.Name())
-			if seen[installPath] {
-				continue
-			}
-			seen[installPath] = true
-			skills = append(skills, readSkillRecord(installPath, entry.Name()))
+			seen[discovery.SkillRoot] = true
+			skills = append(skills, readSkillRecord(discovery.SkillRoot, discovery.RelativePath))
 		}
 	}
 	sort.Slice(skills, func(i, j int) bool {
@@ -64,7 +81,63 @@ func scanWorkspaceSkills(workspacePath string) []SkillRecord {
 	return skills
 }
 
+func discoverSkillDirs(root string, maxDepth int) []skillDiscovery {
+	root = filepath.Clean(strings.TrimSpace(root))
+	if root == "" {
+		return nil
+	}
+	if maxDepth <= 0 {
+		maxDepth = skillDiscoveryMaxDepth
+	}
+	result := make([]skillDiscovery, 0)
+	var walk func(currentRoot, relativePrefix string, depth int)
+	walk = func(currentRoot, relativePrefix string, depth int) {
+		entries, err := os.ReadDir(currentRoot)
+		if err != nil {
+			return
+		}
+		for _, entry := range entries {
+			name := strings.TrimSpace(entry.Name())
+			if name == "" || strings.HasPrefix(name, ".") || name == ".tmp" || !entry.IsDir() {
+				continue
+			}
+			skillRoot := filepath.Join(currentRoot, name)
+			relativePath := name
+			if relativePrefix != "" {
+				relativePath = relativePrefix + "/" + name
+			}
+			relativePath = strings.Trim(strings.ReplaceAll(relativePath, "\\", "/"), "/")
+			if relativePath == "" || strings.Contains(relativePath, "..") {
+				continue
+			}
+			if hasSkillManifest(skillRoot) {
+				result = append(result, skillDiscovery{
+					RelativePath: relativePath,
+					SkillRoot:    skillRoot,
+				})
+				continue
+			}
+			if depth < maxDepth {
+				walk(skillRoot, relativePath, depth+1)
+			}
+		}
+	}
+	walk(root, "", 1)
+	return result
+}
+
+func hasSkillManifest(skillRoot string) bool {
+	for _, name := range []string{"SKILL.md", "skill.json", "openclaw.skill.json"} {
+		info, err := os.Stat(filepath.Join(skillRoot, name))
+		if err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
 func readSkillRecord(installPath, fallbackID string) SkillRecord {
+	fallbackID = strings.Trim(strings.ReplaceAll(strings.TrimSpace(fallbackID), "\\", "/"), "/")
 	record := SkillRecord{
 		SkillID:     fallbackID,
 		Identifier:  fallbackID,

--- a/clawmanager-agent/internal/gateway/skills_test.go
+++ b/clawmanager-agent/internal/gateway/skills_test.go
@@ -33,3 +33,22 @@ func TestScanWorkspaceSkillsIncludesHermesSkillRoot(t *testing.T) {
 		t.Fatalf("Identifier = %q, want hermes-weather", skills[0].Identifier)
 	}
 }
+
+func TestScanWorkspaceSkillsIncludesNestedCategorySkill(t *testing.T) {
+	workspace := t.TempDir()
+	skillDir := filepath.Join(workspace, "home", ".hermes", "skills", "productivity", "my-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# my skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := scanWorkspaceSkills(workspace)
+	if len(skills) != 1 {
+		t.Fatalf("skills len = %d, want 1: %#v", len(skills), skills)
+	}
+	if skills[0].Identifier != "productivity/my-skill" {
+		t.Fatalf("Identifier = %q, want productivity/my-skill", skills[0].Identifier)
+	}
+}

--- a/clawmanager-agent/internal/gateway/types.go
+++ b/clawmanager-agent/internal/gateway/types.go
@@ -254,3 +254,10 @@ type SkillRecord struct {
 type HeartbeatReporter interface {
 	ReportHeartbeat(context.Context, HeartbeatPayload) error
 }
+
+// SkillsReporter is implemented by the runtime agent process control plane uses
+// when ClawManager requests an on-demand skill inventory resync.
+type SkillsReporter interface {
+	ReportSkills(context.Context, SkillReportPayload) error
+	PodID() int
+}

--- a/clawmanager-agent/internal/instanceagent/skills.go
+++ b/clawmanager-agent/internal/instanceagent/skills.go
@@ -31,27 +31,11 @@ func ScanSkills(dirs []string) ([]SkillInfo, error) {
 	seen := map[string]bool{}
 
 	for _, dir := range dirs {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
+		if err := scanSkillDirectory(dir, seen, &skills); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			return nil, err
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() || isHiddenSegment(entry.Name()) {
-				continue
-			}
-			path := filepath.Join(dir, entry.Name())
-			if seen[path] {
-				continue
-			}
-			seen[path] = true
-			skill, err := InspectSkill(path)
-			if err != nil {
-				continue
-			}
-			skills = append(skills, skill)
 		}
 	}
 
@@ -59,6 +43,46 @@ func ScanSkills(dirs []string) ([]SkillInfo, error) {
 		return skills[i].Identifier < skills[j].Identifier
 	})
 	return skills, nil
+}
+
+func scanSkillDirectory(dir string, seen map[string]bool, skills *[]SkillInfo) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || isHiddenSegment(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+
+		if isSkillDirectory(path) {
+			skill, err := InspectSkill(path)
+			if err != nil {
+				continue
+			}
+			*skills = append(*skills, skill)
+			continue
+		}
+
+		// Hermes category folders (e.g. social-media/, research/) only contain
+		// DESCRIPTION.md and nested skills. Recurse into children instead of
+		// treating the category directory itself as a skill.
+		if err := scanSkillDirectory(path, seen, skills); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isSkillDirectory(path string) bool {
+	manifestName, _ := readSkillManifest(path)
+	return manifestName != ""
 }
 
 func InspectSkill(path string) (SkillInfo, error) {
@@ -71,6 +95,9 @@ func InspectSkill(path string) (SkillInfo, error) {
 	}
 
 	manifestName, manifest := readSkillManifest(path)
+	if manifestName == "" {
+		return SkillInfo{}, errors.New("skill directory must contain SKILL.md, skill.json, or manifest.json")
+	}
 	contentMD5, sizeBytes, fileCount, err := ContentMD5(path)
 	if err != nil {
 		return SkillInfo{}, err

--- a/clawmanager-agent/internal/instanceagent/skills_test.go
+++ b/clawmanager-agent/internal/instanceagent/skills_test.go
@@ -128,6 +128,41 @@ func TestCreateSkillPackageUsesSpecContentWithSingleTopDirectory(t *testing.T) {
 	}
 }
 
+func TestScanSkillsSkipsCategoryDirectories(t *testing.T) {
+	root := t.TempDir()
+
+	categoryDir := filepath.Join(root, "social-media")
+	mustMkdir(t, categoryDir)
+	mustWriteFile(t, filepath.Join(categoryDir, "DESCRIPTION.md"), []byte("# Social\n"))
+
+	nestedSkillDir := filepath.Join(categoryDir, "xurl")
+	mustMkdir(t, nestedSkillDir)
+	mustWriteFile(t, filepath.Join(nestedSkillDir, "SKILL.md"), []byte("# xurl skill\n"))
+
+	topLevelSkillDir := filepath.Join(root, "dogfood")
+	mustMkdir(t, topLevelSkillDir)
+	mustWriteFile(t, filepath.Join(topLevelSkillDir, "SKILL.md"), []byte("# dogfood\n"))
+
+	skills, err := ScanSkills([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d: %+v", len(skills), skills)
+	}
+
+	identifiers := []string{skills[0].Identifier, skills[1].Identifier}
+	sort.Strings(identifiers)
+	if identifiers[0] != "dogfood" || identifiers[1] != "xurl" {
+		t.Fatalf("unexpected skill identifiers: %v", identifiers)
+	}
+	for _, skill := range skills {
+		if skill.Identifier == "social-media" {
+			t.Fatalf("category directory should not be treated as a skill: %+v", skill)
+		}
+	}
+}
+
 func TestScanSkillsReadsSkillJSON(t *testing.T) {
 	root := t.TempDir()
 	skillDir := filepath.Join(root, "weather")

--- a/hermes/Dockerfile.agent-overlay
+++ b/hermes/Dockerfile.agent-overlay
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+#
+# Local/release-smoke image: keep the published Hermes Lite runtime as-is,
+# only rebuild and replace clawmanager-agent (the ClawManager control plane).
+#
+# Build from repository root (runtimeagent/):
+#   docker build -f hermes/Dockerfile.agent-overlay \
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest \
+#     -t hermes-lite:local .
+
+ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+
+WORKDIR /src/clawmanager-agent
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+COPY clawmanager-agent ./
+RUN go mod download
+
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+        go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+FROM ${BASE_IMAGE}
+
+COPY --from=clawmanager-agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+RUN chmod 755 /usr/local/bin/clawmanager-agent

--- a/hermes/Dockerfile.agent-overlay.nosyntax
+++ b/hermes/Dockerfile.agent-overlay.nosyntax
@@ -1,0 +1,30 @@
+# Local/release-smoke image without BuildKit dockerfile frontend pull.
+# Use when Docker Hub cannot resolve docker/dockerfile:1.7.
+#
+#   docker build -f hermes/Dockerfile.agent-overlay.nosyntax \
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest \
+#     -t hermes-lite:local .
+
+ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+
+WORKDIR /src/clawmanager-agent
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+COPY clawmanager-agent ./
+RUN go mod download
+
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+        go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+FROM ${BASE_IMAGE}
+
+COPY --from=clawmanager-agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+RUN chmod 755 /usr/local/bin/clawmanager-agent

--- a/hermes/Dockerfile.pro-agent-overlay.nosyntax
+++ b/hermes/Dockerfile.pro-agent-overlay.nosyntax
@@ -1,0 +1,29 @@
+# Pro Hermes dedicated image overlay (not the lite pool).
+#
+#   docker build -f hermes/Dockerfile.pro-agent-overlay.nosyntax `
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes:latest `
+#     -t hermes:local .
+
+ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+
+WORKDIR /src/clawmanager-agent
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+COPY clawmanager-agent ./
+RUN go mod download
+
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+        go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+FROM ${BASE_IMAGE}
+
+COPY --from=clawmanager-agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+RUN chmod 755 /usr/local/bin/clawmanager-agent

--- a/hermes/internal/agent/skills.go
+++ b/hermes/internal/agent/skills.go
@@ -31,27 +31,11 @@ func ScanSkills(dirs []string) ([]SkillInfo, error) {
 	seen := map[string]bool{}
 
 	for _, dir := range dirs {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
+		if err := scanSkillDirectory(dir, seen, &skills); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			return nil, err
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() || isHiddenSegment(entry.Name()) {
-				continue
-			}
-			path := filepath.Join(dir, entry.Name())
-			if seen[path] {
-				continue
-			}
-			seen[path] = true
-			skill, err := InspectSkill(path)
-			if err != nil {
-				continue
-			}
-			skills = append(skills, skill)
 		}
 	}
 
@@ -59,6 +43,43 @@ func ScanSkills(dirs []string) ([]SkillInfo, error) {
 		return skills[i].Identifier < skills[j].Identifier
 	})
 	return skills, nil
+}
+
+func scanSkillDirectory(dir string, seen map[string]bool, skills *[]SkillInfo) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || isHiddenSegment(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+
+		if isSkillDirectory(path) {
+			skill, err := InspectSkill(path)
+			if err != nil {
+				continue
+			}
+			*skills = append(*skills, skill)
+			continue
+		}
+
+		if err := scanSkillDirectory(path, seen, skills); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isSkillDirectory(path string) bool {
+	manifestName, _ := readSkillManifest(path)
+	return manifestName != ""
 }
 
 func InspectSkill(path string) (SkillInfo, error) {
@@ -71,6 +92,9 @@ func InspectSkill(path string) (SkillInfo, error) {
 	}
 
 	manifestName, manifest := readSkillManifest(path)
+	if manifestName == "" {
+		return SkillInfo{}, errors.New("skill directory must contain SKILL.md, skill.json, or manifest.json")
+	}
 	contentMD5, sizeBytes, fileCount, err := ContentMD5(path)
 	if err != nil {
 		return SkillInfo{}, err

--- a/openclaw/Dockerfile.agent-overlay.nosyntax
+++ b/openclaw/Dockerfile.agent-overlay.nosyntax
@@ -1,0 +1,36 @@
+# Local/release-smoke: published OpenClaw (lite or pro) + new clawmanager-agent only.
+#
+# From repository root (runtimeagent/):
+#   # Lite pool
+#   docker build -f openclaw/Dockerfile.agent-overlay.nosyntax `
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/openclaw-lite:latest `
+#     -t openclaw-lite:local .
+#
+#   # Pro dedicated
+#   docker build -f openclaw/Dockerfile.agent-overlay.nosyntax `
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/openclaw:latest `
+#     -t openclaw:local .
+
+ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/openclaw-lite:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+
+WORKDIR /src/clawmanager-agent
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+COPY clawmanager-agent ./
+RUN go mod download
+
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+        go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+FROM ${BASE_IMAGE}
+
+COPY --from=clawmanager-agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+RUN chmod 755 /usr/local/bin/clawmanager-agent


### PR DESCRIPTION
## 摘要
- 存在 Pro instance 凭据时，优先进入 instance 模式，不再误入 Lite runtime-pod
- 将 `desktop` / `gateway` 视为后端标记，不据此拒绝 Hermes Pro instance
- 新增控制面 `POST /v1/skills/resync`，支持按需技能库存上报
- Hermes/instance 侧支持分类目录下的嵌套 skill 发现（含对应测试）
- 补充 agent-overlay Dockerfile，便于本地只替换 clawmanager-agent 做冒烟验证

## 测试计划
- [x] `go test`：cmd / agent / control / gateway / instanceagent / runtime/openclaw
- [x] 本地 overlay 构建 `hermeslocal-fix`，ClawManager Hermes Pro（DESKTOP）实机验证通过
- [ ] （可选）Hermes Lite 换本地 overlay 后验证 skills resync 与嵌套 skill 扫描