### PR TITLE
fix(openclaw): enable bounded browser verification for Lite team members

### DIFF
--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -17,6 +17,7 @@ const openClawTrustedProxyRequiredHeader = "x-forwarded-proto"
 const openClawAutoProviderName = "auto"
 const openClawRedisTeamPluginID = "redis-team"
 const openClawRedisTeamPluginDirEnv = "CLAWMANAGER_OPENCLAW_REDIS_TEAM_PLUGIN_DIR"
+const openClawBrowserExecutablePath = "/usr/bin/chromium"
 
 func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string) error {
 	if err := gateway.WriteLiteTeamConfigJSON(req, workspacePath); err != nil {
@@ -41,6 +42,7 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read openclaw config: %w", err)
 	}
+	configureManagedOpenClawBrowser(config)
 
 	if teamEnabledFromRequest(req) {
 		if err := configureOpenClawRedisTeam(config, req, workspacePath); err != nil {
@@ -104,6 +106,25 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 		}
 	}
 	return nil
+}
+
+// configureManagedOpenClawBrowser supplies the safe Lite runtime defaults that
+// are present in the image template without replacing an instance's explicit
+// browser choices. New pooled workspaces start from an empty config, so relying
+// on the image template alone leaves Browser unavailable for those instances.
+func configureManagedOpenClawBrowser(config map[string]any) {
+	browser := ensureObject(config, "browser")
+	setDefaultObjectValue(browser, "enabled", true)
+	setDefaultObjectValue(browser, "executablePath", openClawBrowserExecutablePath)
+	setDefaultObjectValue(browser, "headless", true)
+	setDefaultObjectValue(browser, "noSandbox", true)
+}
+
+func setDefaultObjectValue(object map[string]any, key string, value any) {
+	if _, exists := object[key]; exists {
+		return
+	}
+	object[key] = value
 }
 
 func configureOpenClawRedisTeam(config map[string]any, req gateway.CreateGatewayRequest, workspacePath string) error {

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -146,6 +146,13 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 	if autoProvider["api"] != "openai-completions" {
 		t.Fatalf("models.providers.auto.api = %#v, want openai-completions", autoProvider["api"])
 	}
+	browser := objectAt(t, merged, "browser")
+	if browser["enabled"] != true || browser["headless"] != true || browser["noSandbox"] != true {
+		t.Fatalf("browser defaults = %#v, want enabled headless no-sandbox browser", browser)
+	}
+	if browser["executablePath"] != openClawBrowserExecutablePath {
+		t.Fatalf("browser.executablePath = %#v, want %s", browser["executablePath"], openClawBrowserExecutablePath)
+	}
 	providerModels, ok := autoProvider["models"].([]any)
 	if !ok {
 		t.Fatalf("models.providers.auto.models = %#v, want array", autoProvider["models"])
@@ -162,6 +169,69 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 			t.Fatalf("config mode = %o, want 0600", info.Mode().Perm())
 		}
 	}
+}
+
+func TestWriteOpenClawGatewayConfigCompletesPartialBrowserConfig(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-64")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"browser":{"enabled":false,"profile":"team-review"}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	req := CreateGatewayRequest{InstanceID: 64, UserID: 45, UID: 200064, GID: 200064}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	merged := readOpenClawConfigForTest(t, configPath)
+	browser := objectAt(t, merged, "browser")
+	if browser["enabled"] != false {
+		t.Fatalf("browser.enabled = %#v, want explicit false preserved", browser["enabled"])
+	}
+	if browser["profile"] != "team-review" {
+		t.Fatalf("browser.profile = %#v, want preserved custom profile", browser["profile"])
+	}
+	if browser["executablePath"] != openClawBrowserExecutablePath || browser["headless"] != true || browser["noSandbox"] != true {
+		t.Fatalf("completed browser config = %#v", browser)
+	}
+}
+
+func TestWriteOpenClawGatewayConfigPreservesExplicitBrowserConfig(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-65")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	existing := []byte(`{"browser":{"enabled":false,"executablePath":"/opt/custom-browser","headless":false,"noSandbox":false}}`)
+	if err := os.WriteFile(configPath, existing, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	req := CreateGatewayRequest{InstanceID: 65, UserID: 45, UID: 200065, GID: 200065}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	browser := objectAt(t, readOpenClawConfigForTest(t, configPath), "browser")
+	if browser["enabled"] != false || browser["executablePath"] != "/opt/custom-browser" || browser["headless"] != false || browser["noSandbox"] != false {
+		t.Fatalf("explicit browser config was overwritten: %#v", browser)
+	}
+}
+
+func readOpenClawConfigForTest(t *testing.T, configPath string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	return config
 }
 
 func TestWriteOpenClawGatewayConfigUsesRequestEnvironmentLLMOverrides(t *testing.T) {

--- a/plugins/openclaw-redis-team/dist/index.js
+++ b/plugins/openclaw-redis-team/dist/index.js
@@ -1263,6 +1263,43 @@ function startAssignmentHeartbeat({ envelope, emitTaskEvent, log, isTerminal }) 
   return stop;
 }
 
+function resolveRedisTeamVerificationRole(envelope) {
+  const profileKey = trim(
+    envelope?.profileKey ||
+      envelope?.profile_key ||
+      envelope?.memberContext?.profileKey ||
+      envelope?.memberContext?.profile_key ||
+      process.env.CLAWMANAGER_TEAM_PROFILE_KEY,
+  ).toLowerCase();
+  if (profileKey === "agency.evidence-collector") return "evidence";
+  if (profileKey === "agency.code-reviewer") return "code-review";
+  if (profileKey === "agency.api-tester") return "api-test";
+
+  const role = trim(
+    envelope?.effectiveRole ||
+      envelope?.effective_role ||
+      envelope?.role ||
+      process.env.CLAWMANAGER_TEAM_ROLE,
+  ).toLowerCase();
+  if (["reviewer", "qa", "qa-engineer", "evidence-collector"].includes(role)) return "evidence";
+  if (role === "code-reviewer") return "code-review";
+  if (role === "api-tester") return "api-test";
+  return "";
+}
+
+function redisTeamVerificationGuidance(envelope) {
+  switch (resolveRedisTeamVerificationRole(envelope)) {
+    case "evidence":
+      return "Evidence verification policy: use source, artifacts, and tools already available. Browser verification is optional unless explicitly required; attempt Browser startup at most twice and spend at most 45 seconds total on Browser setup. Never install or download browsers, drivers, test frameworks, package dependencies, or system packages for verification. If Browser remains unavailable, record browserVerification=unavailable and continue with static/manual checks. Report only actual findings; do not target a fixed issue count.";
+    case "code-review":
+      return "Code review policy: review source, diffs, architecture boundaries, and existing test evidence first. Keep review proportional and report only concrete findings. Do not create a new test environment or install/download browsers, drivers, frameworks, package dependencies, or system packages. Browser is normally unnecessary; if explicitly useful and ready, attempt startup at most twice and stop Browser setup after 45 seconds before continuing with source review.";
+    case "api-test":
+      return "API verification policy: use existing HTTP tools, available endpoints, artifacts, and static contract review. Browser verification is not required. Never install or download Postman, Newman, browsers, test frameworks, package dependencies, or system packages. If the service or network target is unavailable, record the limit and continue with static contract checks; report only directly observed reproducible failures.";
+    default:
+      return "";
+  }
+}
+
 function appendRedisTeamCompletionGuidance(text, envelope) {
   const body = String(text || "");
   if (isContextOnlyEnvelope(envelope)) return body;
@@ -1288,6 +1325,8 @@ function appendRedisTeamCompletionGuidance(text, envelope) {
     "Optional-work rule: optional work may be omitted, but every omitted optional assignment must be listed in skippedAssignments with assignmentId and a concrete reason.",
     "Never list, search, resolve, or scan the parent of the current Team shared directory, and never inspect sibling Team directories.",
   ];
+  const verificationGuidance = redisTeamVerificationGuidance(envelope);
+  if (verificationGuidance) guidance.push(verificationGuidance);
   if (physicalSharedDir) guidance.push("Resolved current-Team physical shared directory: " + physicalSharedDir);
   if (memberArtifactRoot) guidance.push("Resolved current-member artifact directory: " + memberArtifactRoot);
   return guidance.join("\n");

--- a/plugins/openclaw-redis-team/scripts/build-check.mjs
+++ b/plugins/openclaw-redis-team/scripts/build-check.mjs
@@ -102,11 +102,33 @@ for (const token of [
   "assistant_session",
   "already_terminal",
   "suppressed duplicate reply after submitted completion",
+  "resolveRedisTeamVerificationRole",
+  "Evidence verification policy:",
+  "Code review policy:",
+  "API verification policy:",
+  "attempt Browser startup at most twice",
+  "at most 45 seconds total on Browser setup",
+  "Never install or download browsers",
 ]) {
   if (!dist.includes(token)) throw new Error(`dist/index.js missing Redis Team completion token: ${token}`);
 }
 if (dist.includes("params.taskId === activeEnvelope.taskId")) {
   throw new Error("dist/index.js must match active Redis Team task ids through aliases");
+}
+const verificationRoleResolverStart = dist.indexOf("function resolveRedisTeamVerificationRole");
+const verificationRoleResolverEnd = dist.indexOf("function redisTeamVerificationGuidance", verificationRoleResolverStart);
+if (verificationRoleResolverStart < 0 || verificationRoleResolverEnd < 0) {
+  throw new Error("unable to locate validation role resolver");
+}
+const verificationRoleResolver = dist.slice(verificationRoleResolverStart, verificationRoleResolverEnd);
+for (const forbiddenRolePattern of [
+  'role.includes("review")',
+  'role.includes("qa")',
+  'profileKey.includes("review")',
+]) {
+  if (verificationRoleResolver.includes(forbiddenRolePattern)) {
+    throw new Error(`validation role matching must use exact aliases, found: ${forbiddenRolePattern}`);
+  }
 }
 if (dist.includes('path.join(cfg.sharedDir, ".openclaw-redis-team", "tasks"')) {
   throw new Error("member-scoped Redis Team envelopes must not require a shared NFS .openclaw-redis-team/tasks directory");


### PR DESCRIPTION
## Summary

This PR makes Browser configuration and validation behavior reliable for managed OpenClaw Lite Team instances.

### Managed Browser defaults

New pooled OpenClaw workspaces may start with an empty `openclaw.json` instead of inheriting the image template. The gateway config writer now supplies safe defaults when individual Browser fields are missing:

```json
{
  "browser": {
    "enabled": true,
    "executablePath": "/usr/bin/chromium",
    "headless": true,
    "noSandbox": true
  }
}