### PR TITLE
feat(openclaw): support managed Lite gateway defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ runtimeagent/
 clawmanager-agent/clawmanager-agent-linux
 .tmp-openclaw-patch.json
 /runtime-team-optimization-docs/
+.codex

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,9 @@ The repository currently documents these runtime images:
 - `openclaw-shell/`: Alpine-based OpenClaw shell runtime image, built from the repository root so it can reuse the OpenClaw agent implementation under `openclaw/`
 - `clawmanager-agent/`: shared managed-runtime agent used by runtime images that need ClawManager runtime gateway control
 
+Before adding or upgrading a channel plugin in OpenClaw Lite, read the
+[OpenClaw Lite Channel Adapter Guide](clawmanager-agent/docs/openclaw-lite-channel-adaptation.md).
+
 ## Manual builds
 
 You can build each runtime image directly with Docker from the repository root.

--- a/clawmanager-agent/README.md
+++ b/clawmanager-agent/README.md
@@ -40,7 +40,25 @@ Runtime images should install the binary at:
 - `RUNTIME_GATEWAY_COMMAND`: required for unknown or generic runtime types
 - `RUNTIME_WORKSPACE_ROOT`: workspace root, defaults to the selected profile
 - `RUNTIME_AGENT_DATA_DIR`: local agent data directory
+- `CLAWMANAGER_OPENCLAW_NPM_RUNTIME_MODE`: OpenClaw npm bootstrap mode. The
+  default `shared` mode creates instance-owned package directories with
+  read-only links to image-provided packages, avoiding a full `node_modules`
+  copy for every gateway. Set it to `copy` to restore the legacy behavior.
+
+The shared npm mode applies only when a new instance npm directory is seeded.
+Existing instance npm directories are preserved. Image-provided packages are
+read-only through their links; installing or replacing a package writes an
+instance-owned override without changing the image defaults.
+
+Gateway state changes trigger an immediate report to ClawManager. An OpenClaw
+instance becomes `running` only after its existing gateway health check passes;
+required config and plugin registry preparation still finish before launch.
 
 ## Extending
 
 Read [Runtime Profile Extension Guide](docs/runtime-profile-extension.md) before adding a new runtime profile.
+
+Read [OpenClaw Lite Channel Adapter Guide](docs/openclaw-lite-channel-adaptation.md)
+before adding or upgrading a channel plugin in the Lite image. It documents the
+shared npm layout, cross-UID permissions, Node peer resolution, readiness
+boundary, rollout checks, and known failure modes.

--- a/clawmanager-agent/docs/openclaw-lite-channel-adaptation.md
+++ b/clawmanager-agent/docs/openclaw-lite-channel-adaptation.md
@@ -1,0 +1,187 @@
+# OpenClaw Lite Channel 适配指南
+
+本文记录 ClawManager 在 OpenClaw Lite 多实例运行时中适配 channel 插件的约束、实现位置、验证方法和常见故障。新增或升级钉钉、飞书、企业微信等 channel 时，应先阅读本文。
+
+## 1. 适用范围
+
+本文只描述 OpenClaw Lite：一个 runtime Pod 内由 `clawmanager-agent` 启动多个、使用不同 UID/GID、workspace 和端口的 OpenClaw gateway 进程。
+
+它与普通单实例 OpenClaw 镜像有两个关键区别：
+
+- runtime Pod 内的 gateway 不是镜像默认用户，而是实例专属 UID，例如 `200000 + instanceID`。
+- 批量创建时不能为每个实例完整复制或在线安装一份 `node_modules`，否则启动时间、磁盘和元数据操作会随实例数线性增长。
+
+Lite 的默认策略是“镜像预装、共享只读包、实例目录可覆盖”。
+
+## 2. 当前目录模型
+
+| 用途 | 路径 | 所有权/写入策略 |
+| --- | --- | --- |
+| 镜像插件模板 | `/defaults/.openclaw/npm` | 镜像构建期生成，运行时所有实例只读 |
+| 全局 OpenClaw 包 | `/usr/local/lib/node_modules/openclaw` | 镜像提供，只读 |
+| 实例 OpenClaw 状态 | `<workspace>/home/.openclaw` | 实例 UID/GID 所有，可写 |
+| 实例 npm 根目录 | `<workspace>/home/.openclaw/npm` | 实例所有；默认只链接镜像包 |
+| 插件注册表 | `<workspace>/home/.openclaw/plugins/installs.json` | 实例所有，路径在启动前重写 |
+
+`CLAWMANAGER_OPENCLAW_NPM_RUNTIME_MODE` 控制 npm 初始化方式：
+
+- `shared`：默认。创建实例自己的 scope 目录，将镜像中的 package 链接进去。
+- `copy`：兼容模式。首次创建时完整复制 npm 目录，启动更慢、空间占用更大。
+
+已有实例 npm 目录不会被覆盖。OpenClaw repair 或人工复制产生的实例包会成为实例级 override，后续更新镜像中的共享包也不会替换它。
+
+## 3. gateway 启动顺序
+
+Lite 创建 gateway 时，`WriteGatewayConfig` 在启动进程前完成以下步骤：
+
+1. 校验实例 workspace、`HOME` 和持久化目录。
+2. 修复 `/defaults/.openclaw` 父目录和 npm 根目录的可读、可遍历权限。
+3. 根据 `shared` 或 `copy` 模式初始化实例 npm 目录。
+4. 准备 channel 所需的 peer package。
+5. 复制实例可写的 `plugins`、`extensions` 和注册表，并重写 `/defaults` 路径。
+6. 合并 `CLAWMANAGER_OPENCLAW_CHANNELS_JSON`，同步启用对应 plugin。
+7. 将实例目录和配置归属到请求中的 UID/GID。
+8. 启动已经指定端口的 `openclaw` 进程并执行 gateway 健康检查。
+
+相关实现：
+
+- `internal/runtime/openclaw/config_writer.go`
+- `internal/runtime/openclaw/plugin_runtime.go`
+- `internal/runtime/openclaw/plugin_runtime_test.go`
+- `scripts/clawmanager-agent-run`
+- `../../openclaw/Dockerfile.openclaw`
+
+## 4. 新增 channel 的适配步骤
+
+### 4.1 明确 channel ID、plugin ID 和 npm package
+
+这三个名称可能不同，不能根据产品名称猜测。例如钉钉当前使用：
+
+- channel ID：`dingtalk-connector`
+- plugin ID：`dingtalk-connector`
+- npm package：`@dingtalk-real-ai/dingtalk-connector`
+
+需要同时检查插件的 `openclaw.plugin.json` 和 `package.json`。ClawManager 下发的 channel key 必须能被 OpenClaw 识别，`openClawEnvManagedChannelPlugins` 必须把该 key 映射到正确的 plugin ID。
+
+新增映射时同时添加配置写入测试，至少覆盖：
+
+- 配置该 channel 时只启用对应 plugin。
+- 未配置时保持默认禁用。
+- 切换 channel 后禁用旧的受管 plugin。
+- 非法 JSON 和非对象 payload 返回明确错误。
+
+### 4.2 在镜像中预装完整依赖
+
+channel package 必须在镜像构建期安装到 `/defaults`，不能把 `npm install` 放到实例启动路径中：
+
+```dockerfile
+HOME=/defaults openclaw plugins install <package-spec>
+```
+
+构建后要检查插件目录内的生产依赖是否完整。只复制插件源码或只复制 `dist` 目录可能遗漏 `axios` 等运行时依赖，表现为插件已发现但加载时报 `ERR_MODULE_NOT_FOUND`。
+
+不要依赖 `openclaw plugins repair` 完成首次启动。repair 可能把共享插件复制进实例目录，使单个实例暂时恢复，却会形成不可由新镜像更新的 override，并重新引入批量复制成本。
+
+### 4.3 处理 Node peer dependency 和 realpath
+
+如果 channel 的 `peerDependencies` 包含 `openclaw`，只在实例 npm 根目录创建 peer 链接并不总是有效。
+
+Node 会先解析插件符号链接的真实路径。共享模式下，插件真实路径位于：
+
+```text
+/defaults/.openclaw/npm/node_modules/<channel-package>
+```
+
+因此 Node 会从 `/defaults/...` 向上寻找 `openclaw`，不会回到实例 npm 根目录。共享 npm 根目录必须存在：
+
+```text
+/defaults/.openclaw/npm/node_modules/openclaw
+  -> /usr/local/lib/node_modules/openclaw
+```
+
+实例 npm 根目录也保留同名 peer 链接，以兼容实例 override 或 copy 模式。
+
+当前 `ensureDingTalkOpenClawPeer` 只在检测到钉钉 connector 时创建该链接。适配其他具有 `openclaw` peer dependency 的 channel 时，应扩展或泛化这段逻辑，并增加并发幂等测试；不能只修改 Dockerfile。
+
+### 4.4 满足跨 UID 权限和 OpenClaw 信任检查
+
+所有实例 UID 都必须能够读取并遍历共享 package，但不应拥有共享目录。镜像至少保证：
+
+- `/defaults` 和 `/defaults/.openclaw` 可遍历。
+- `/defaults/.openclaw/npm` 下文件对其他 UID 可读、目录可遍历。
+- 共享的第三方 channel package 使用受信任的 root 所有权。
+- 符号链接本身和目标路径均可访问。
+
+新增预装 channel 后，要把它的 package 目录加入 Dockerfile 的 root ownership 处理。不要把共享目录 `chown` 给某个实例 UID；那会让其他实例失败，也会造成实例间所有权争用。
+
+镜像基础初始化可能在容器启动时重新设置 `/defaults` 权限，所以 `ensureOpenClawDefaultsTraversal` 是 gateway 创建前的最后一道兜底，不能只依赖 Dockerfile 中的 `chmod`。
+
+### 4.5 区分 gateway Available 与 channel Ready
+
+ClawManager Lite 在 gateway HTTP 健康检查通过后即可报告实例可用。配置写入、plugin registry 和模块解析必须在进程启动前完成；channel 的网络连接和握手可以在 gateway 启动后异步进行。
+
+因此：
+
+- `Available` 表示用户可以进入 OpenClaw，通常目标是创建后约 5 秒。
+- `Available` 不承诺钉钉、飞书等外部 channel 已完成长连接握手。
+- 若产品需要展示 channel 可用性，应单独上报 channel 状态，不要延长 gateway 的可用时间。
+- 自动化端到端测试发送首条消息时应允许短暂重试，并分别记录 gateway ready 和 channel ready 时间。
+
+## 5. 验证清单
+
+### 5.1 镜像级验证
+
+- package、manifest、入口文件和生产依赖存在。
+- `/defaults` 权限允许任意实例 UID 读取和遍历。
+- 共享 package 为受信任所有者。
+- 所需 peer 链接目标存在。
+- `openclaw plugins list` 不出现 stale、ownership、permission 或 module resolution 错误。
+
+### 5.2 单实例验证
+
+以实例 UID 运行模块解析，而不是以 root 验证：
+
+```bash
+readlink -f <instance-home>/.openclaw/npm/node_modules/<channel-package>
+readlink /defaults/.openclaw/npm/node_modules/openclaw
+```
+
+检查配置时只输出 channel key 和 enabled 状态，不输出 client secret、token 或消息正文。
+
+端到端验证至少覆盖：
+
+1. channel 启动成功。
+2. 外部平台消息进入实例。
+3. Agent 创建或更新会话。
+4. 回复成功发送到原 channel。
+5. 日志中没有 plugin load、peer dependency 或权限错误。
+
+### 5.3 批量验证
+
+建议依次创建 1、10、100 个实例，记录：
+
+- gateway ready 的平均值、P95 和最大值。
+- 成功、失败、重复端口和缺失进程数量。
+- runtime Pod 间的实例分布。
+- 共享目录是否保持稳定所有权和权限。
+- 是否发生实例级完整 npm 复制或在线安装。
+
+## 6. 常见故障
+
+| 现象 | 常见原因 | 处理方向 |
+| --- | --- | --- |
+| `plugin not found (stale config entry)` | registry 仍指向旧路径，或实例 UID 无法遍历 `/defaults` | 检查 registry 重写与父目录权限 |
+| ownership/permission blocked | 共享 package 所有者或模式不满足信任检查 | 修复镜像 ownership，并保留启动前权限兜底 |
+| `Cannot find module 'openclaw/plugin-sdk/core'` | peer 链接只在实例目录，Node realpath 从共享目录解析 | 在共享 npm 根目录提供 `openclaw` peer |
+| `Cannot find package 'axios'` 等 | package 生产依赖不完整，或 repair/copy 只复制了部分内容 | 检查镜像安装结果和实例 override |
+| 配置了钉钉但启动了企业微信 | ClawManager channel key、plugin 映射或保存 payload 错误 | 只检查配置 key，核对前后端映射和 `openClawEnvManagedChannelPlugins` |
+| 只有 repair 后可用 | repair 创建了实例副本，掩盖共享路径问题 | 删除测试实例 override，修复镜像和 runtime 初始化 |
+| 少量实例成功、批量失败 | 每实例复制/安装导致 I/O 放大，或共享目录被实例 UID 改写 | 使用 shared 模式，保持共享目录只读和 root 所有 |
+
+## 7. 回归测试位置
+
+- `internal/runtime/openclaw/config_writer_test.go`：channel key 与 plugin 启停映射。
+- `internal/runtime/openclaw/plugin_runtime_test.go`：shared/copy 初始化、peer 链接、权限与并发幂等。
+- `../../openclaw/dockerfile_permissions_test.go`：镜像中的共享目录权限、所有权和 peer 链接。
+
+每次升级 OpenClaw 或 channel package 都应重新执行这些测试，并使用一个没有历史 workspace 的新实例做端到端验证。历史实例可能存在 repair 生成的 override，不能代表新镜像的首次启动行为。

--- a/clawmanager-agent/internal/agent/agent.go
+++ b/clawmanager-agent/internal/agent/agent.go
@@ -166,11 +166,14 @@ func (a *Agent) metricsLoop(ctx context.Context) {
 func (a *Agent) gatewayReportLoop(ctx context.Context) {
 	ticker := time.NewTicker(a.cfg.GatewayReportInterval)
 	defer ticker.Stop()
+	changes := a.manager.GatewayStateChanges()
 	a.reportGateways(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-changes:
+			a.reportGateways(ctx)
 		case <-ticker.C:
 			a.reportGateways(ctx)
 		}

--- a/clawmanager-agent/internal/control/server.go
+++ b/clawmanager-agent/internal/control/server.go
@@ -168,14 +168,7 @@ func writeCreateGatewayError(w http.ResponseWriter, err error) {
 	case errors.Is(err, gateway.ErrRuntimeType), errors.Is(err, gateway.ErrWorkspacePath):
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	case errors.Is(err, gateway.ErrDraining), errors.Is(err, gateway.ErrNoFreePort), errors.Is(err, gateway.ErrStaleGeneration):
-		status := http.StatusConflict
-		if errors.Is(err, gateway.ErrNoFreePort) {
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-			w.WriteHeader(status)
-			_, _ = w.Write([]byte("no free port"))
-			return
-		}
-		http.Error(w, err.Error(), status)
+		http.Error(w, err.Error(), http.StatusConflict)
 	case errors.Is(err, gateway.ErrGatewayStartFailed):
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	default:

--- a/clawmanager-agent/internal/control/server_test.go
+++ b/clawmanager-agent/internal/control/server_test.go
@@ -83,6 +83,34 @@ func TestControlHandlerCreatesIdempotentGatewayAndRejectsNoFreePort(t *testing.T
 	})
 }
 
+func TestGatewayManagerSignalsStartingAndRunningStateChanges(t *testing.T) {
+	cfg := testConfig(t)
+	health := newBlockingHealthChecker()
+	mgr := NewGatewayManager(cfg, &fakeStarter{nextPID: 4242}, NewPortAllocator(func(int) bool { return false }))
+	mgr.SetHealthChecker(health)
+
+	req := testGatewayRequest(cfg.WorkspaceRoot, 125, 45, 7)
+	if _, err := mgr.CreateGateway(context.Background(), req); err != nil {
+		t.Fatalf("CreateGateway() error = %v", err)
+	}
+	select {
+	case <-mgr.GatewayStateChanges():
+	case <-time.After(time.Second):
+		t.Fatal("starting state change was not signaled")
+	}
+
+	health.succeed()
+	select {
+	case <-mgr.GatewayStateChanges():
+	case <-time.After(time.Second):
+		t.Fatal("running state change was not signaled")
+	}
+	eventually(t, func() bool {
+		states := mgr.GatewayStates()
+		return len(states) == 1 && states[0].State == "running"
+	})
+}
+
 func TestControlHandlerSkillsResyncReportsInventory(t *testing.T) {
 	cfg := testConfig(t)
 	reporter := &fakeReporter{podID: 42}
@@ -354,6 +382,40 @@ func TestCreateGatewayWritesConfigPassesTokenAndDoesNotReportRunningWhenOriginPr
 	eventually(t, func() bool { return starter.stopCount() == 1 })
 	if mgr.UsedSlots() != 0 {
 		t.Fatalf("UsedSlots = %d, want failed gateway excluded from capacity", mgr.UsedSlots())
+	}
+}
+
+func TestCreateGatewayReleasesFullPortBlockAfterStartupFailure(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.GatewayPortStart = 20003
+	cfg.GatewayPortEnd = 20005
+	cfg.GatewayPortBlockSize = 3
+	health := &fakeHealthChecker{err: ErrGatewayStartFailed}
+	starter := &fakeStarter{nextPID: 4242}
+	alloc := NewPortAllocator(func(int) bool { return false })
+	mgr := NewGatewayManager(cfg, starter, alloc)
+	mgr.SetHealthChecker(health)
+
+	req := testGatewayRequest(cfg.WorkspaceRoot, 415, 45, 7)
+	req.PortRange = PortRange{Start: 20003, End: 20005}
+	req.GatewayPort = 20003
+	resp, err := mgr.CreateGateway(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreateGateway() error = %v, want async starting response", err)
+	}
+	if resp.Port != 20003 || resp.Status != "starting" {
+		t.Fatalf("CreateGateway() = %+v, want starting on requested port 20003", resp)
+	}
+
+	eventually(t, func() bool {
+		states := mgr.GatewayStates()
+		return len(states) == 1 && states[0].State == "error"
+	})
+	if used := alloc.ListUsed(); len(used) != 0 {
+		t.Fatalf("reserved ports after startup failure = %#v, want all block members released", used)
+	}
+	if _, err := alloc.ReserveExact(416, 7, 20003); err != nil {
+		t.Fatalf("ReserveExact() after startup failure error = %v, want released 20003-20005 block", err)
 	}
 }
 

--- a/clawmanager-agent/internal/control/server_test.go
+++ b/clawmanager-agent/internal/control/server_test.go
@@ -306,17 +306,25 @@ func TestCreateGatewayWritesConfigPassesTokenAndDoesNotReportRunningWhenOriginPr
 	mgr := NewGatewayManager(cfg, starter, NewPortAllocator(func(int) bool { return false }))
 	mgr.SetHealthChecker(health)
 
-	resp, err := mgr.CreateGateway(context.Background(), testGatewayRequest(cfg.WorkspaceRoot, 63, 45, 7))
+	req := testGatewayRequest(cfg.WorkspaceRoot, 63, 45, 7)
+	req.GatewayPort = 20003
+	resp, err := mgr.CreateGateway(context.Background(), req)
 	if err != nil {
 		t.Fatalf("CreateGateway() error = %v, want async starting response", err)
 	}
 	if resp.Status != "starting" {
 		t.Fatalf("CreateGateway().Status = %q, want starting", resp.Status)
 	}
+	if resp.Port != 20003 {
+		t.Fatalf("CreateGateway().Port = %d, want requested 20003", resp.Port)
+	}
 	eventually(t, func() bool { return starter.startCount() == 1 })
 	spec := starter.startedSpec(0)
 	if !stringSlicesEqual(spec.Command, cfg.GatewayCommand) {
 		t.Fatalf("gateway command = %#v, want %#v", spec.Command, cfg.GatewayCommand)
+	}
+	if spec.Port != 20003 {
+		t.Fatalf("GatewayStartSpec.Port = %d, want requested 20003", spec.Port)
 	}
 	if got := envValue(spec.Env, "OPENCLAW_GATEWAY_TOKEN"); got != "" {
 		t.Fatalf("OPENCLAW_GATEWAY_TOKEN = %q, want removed for trusted-proxy auth", got)
@@ -334,6 +342,9 @@ func TestCreateGatewayWritesConfigPassesTokenAndDoesNotReportRunningWhenOriginPr
 	}
 	if !bytes.Contains(data, []byte(`"basePath": "/api/v1/instances/63/proxy"`)) {
 		t.Fatalf("OpenClaw config missing instance proxy basePath: %s", string(data))
+	}
+	if !bytes.Contains(data, []byte(`"port": 20003`)) {
+		t.Fatalf("OpenClaw config missing requested gateway port: %s", string(data))
 	}
 
 	eventually(t, func() bool {

--- a/clawmanager-agent/internal/control/server_test.go
+++ b/clawmanager-agent/internal/control/server_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	hermesruntime "github.com/iamlovingit/clawmanager-agent/internal/runtime/hermes"
 	"github.com/iamlovingit/clawmanager-agent/internal/runtime/openclaw"
 )
 
@@ -193,6 +194,60 @@ func TestManagerReportsCapacityFromAvailablePortBlocks(t *testing.T) {
 	heartbeat := mgr.HeartbeatPayload(11)
 	if heartbeat.MaxGateways != 3 || heartbeat.AvailableSlots != 3 {
 		t.Fatalf("HeartbeatPayload capacity = %+v, want max/available 3 from port blocks", heartbeat)
+	}
+}
+
+func TestHermesManagerUsesAdjacentRequestedSinglePorts(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.RuntimeType = "hermes"
+	cfg.Runtime = hermesruntime.NewProfile("hermes")
+	cfg.GatewayPortStart = 20000
+	cfg.GatewayPortEnd = 20003
+	cfg.GatewayPortBlockSize = 1
+	cfg.GatewayCommand = []string{"start-hermes-dashboard-gateway"}
+	starter := &fakeStarter{nextPID: 4242}
+	mgr := NewGatewayManager(cfg, starter, NewPortAllocator(func(int) bool { return false }))
+
+	for offset := 0; offset < 2; offset++ {
+		instanceID := 70 + offset
+		requestedPort := 20000 + offset
+		req := CreateGatewayRequest{
+			InstanceID:    instanceID,
+			UserID:        45,
+			AgentType:     "hermes",
+			WorkspacePath: filepath.Join(cfg.WorkspaceRoot, "hermes", "user-45", "instance-"+itoa(instanceID)),
+			GatewayPort:   requestedPort,
+			PortRange:     PortRange{Start: 20000, End: 20003},
+			UID:           200000 + instanceID,
+			GID:           200000 + instanceID,
+			Generation:    1,
+		}
+		resp, err := mgr.CreateGateway(context.Background(), req)
+		if err != nil {
+			t.Fatalf("CreateGateway(%d) error = %v", instanceID, err)
+		}
+		if resp.Port != requestedPort {
+			t.Fatalf("CreateGateway(%d).Port = %d, want %d", instanceID, resp.Port, requestedPort)
+		}
+	}
+
+	eventually(t, func() bool { return starter.startCount() == 2 })
+	startedPorts := map[int]struct{}{}
+	for index := 0; index < 2; index++ {
+		spec := starter.startedSpec(index)
+		if spec.Port != 20000 && spec.Port != 20001 {
+			t.Fatalf("Hermes GatewayStartSpec[%d].Port = %d, want 20000 or 20001", index, spec.Port)
+		}
+		if _, exists := startedPorts[spec.Port]; exists {
+			t.Fatalf("Hermes requested port %d started more than once", spec.Port)
+		}
+		startedPorts[spec.Port] = struct{}{}
+		if got := envValue(spec.Env, "CLAWMANAGER_GATEWAY_PORT"); got != strconv.Itoa(spec.Port) {
+			t.Fatalf("Hermes CLAWMANAGER_GATEWAY_PORT = %q, want %d", got, spec.Port)
+		}
+		if got := envValue(spec.Env, "PORT"); got != strconv.Itoa(spec.Port) {
+			t.Fatalf("Hermes PORT = %q, want %d", got, spec.Port)
+		}
 	}
 }
 

--- a/clawmanager-agent/internal/gateway/env_helpers_test.go
+++ b/clawmanager-agent/internal/gateway/env_helpers_test.go
@@ -150,3 +150,45 @@ func TestPrepareLiteTeamSharedWorkspaceRejectsOtherTeamPath(t *testing.T) {
 		t.Fatal("expected cross-Team shared path to be rejected")
 	}
 }
+
+func TestOpenClawGatewayEnvIsolatesInstancePaths(t *testing.T) {
+	base := []string{
+		"HOME=/shared/home",
+		"CLAWMANAGER_WORKSPACE_PATH=/shared/workspace",
+		"CLAWMANAGER_AGENT_PERSISTENT_DIR=/shared/persistent",
+	}
+	tests := []struct {
+		name          string
+		userID        int
+		instanceID    int
+		workspacePath string
+	}{
+		{name: "gateway 123", userID: 45, instanceID: 123, workspacePath: filepath.Join("/workspaces", "openclaw", "user-45", "instance-123")},
+		{name: "gateway 456", userID: 98, instanceID: 456, workspacePath: filepath.Join("/workspaces", "openclaw", "user-98", "instance-456")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := CreateGatewayRequest{
+				AgentType:  "openclaw",
+				UserID:     tc.userID,
+				InstanceID: tc.instanceID,
+				Environment: map[string]string{
+					"HOME":                             "/request/home",
+					"CLAWMANAGER_WORKSPACE_PATH":       "/request/workspace",
+					"CLAWMANAGER_AGENT_PERSISTENT_DIR": "/request/persistent",
+				},
+			}
+			env := OpenClawGatewayEnv(base, Config{RuntimeType: "openclaw", GatewayAuthMode: "trusted-proxy"}, req, tc.workspacePath, 20000+tc.instanceID%100)
+			if got := envValue(env, "CLAWMANAGER_WORKSPACE_PATH"); got != tc.workspacePath {
+				t.Fatalf("CLAWMANAGER_WORKSPACE_PATH = %q, want %q", got, tc.workspacePath)
+			}
+			if got, want := envValue(env, "HOME"), filepath.Join(tc.workspacePath, "home"); got != want {
+				t.Fatalf("HOME = %q, want %q", got, want)
+			}
+			if got, want := envValue(env, "CLAWMANAGER_AGENT_PERSISTENT_DIR"), filepath.Join(tc.workspacePath, "home", ".openclaw"); got != want {
+				t.Fatalf("CLAWMANAGER_AGENT_PERSISTENT_DIR = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/clawmanager-agent/internal/gateway/manager.go
+++ b/clawmanager-agent/internal/gateway/manager.go
@@ -27,6 +27,7 @@ type GatewayManager struct {
 	mu       sync.RWMutex
 	draining bool
 	gateways map[string]*gatewayRecord
+	changes  chan struct{}
 }
 
 func NewGatewayManager(cfg Config, starter ProcessStarter, ports *PortAllocator) *GatewayManager {
@@ -51,6 +52,7 @@ func NewGatewayManager(cfg Config, starter ProcessStarter, ports *PortAllocator)
 		ports:    ports,
 		health:   health,
 		gateways: map[string]*gatewayRecord{},
+		changes:  make(chan struct{}, 1),
 	}
 }
 
@@ -155,6 +157,7 @@ func (m *GatewayManager) CreateGateway(_ context.Context, req CreateGatewayReque
 		UpdatedAt:     now,
 	}
 	m.gateways[gatewayID] = &gatewayRecord{state: state}
+	m.notifyGatewayStateChangedLocked()
 	resp := createGatewayResponse(state)
 	m.mu.Unlock()
 
@@ -167,14 +170,21 @@ func (m *GatewayManager) CreateGateway(_ context.Context, req CreateGatewayReque
 }
 
 func (m *GatewayManager) startGatewayInBackground(gatewayID string, req CreateGatewayRequest, workspacePath string, port int) {
+	startedAt := time.Now()
+	phaseStartedAt := startedAt
 	if err := m.profile().PrepareWorkspace(m.cfg, req, workspacePath); err != nil {
+		log.Printf("runtime-agent gateway startup failed: gateway_id=%s instance_id=%d phase=prepare_workspace phase_ms=%d total_ms=%d error=%v", gatewayID, req.InstanceID, time.Since(phaseStartedAt).Milliseconds(), time.Since(startedAt).Milliseconds(), err)
 		m.markGatewayError(gatewayID, 0, err)
 		return
 	}
+	prepareDuration := time.Since(phaseStartedAt)
+	phaseStartedAt = time.Now()
 	if err := m.profile().WriteGatewayConfig(m.cfg, req, workspacePath, port); err != nil {
+		log.Printf("runtime-agent gateway startup failed: gateway_id=%s instance_id=%d phase=write_config phase_ms=%d total_ms=%d error=%v", gatewayID, req.InstanceID, time.Since(phaseStartedAt).Milliseconds(), time.Since(startedAt).Milliseconds(), err)
 		m.markGatewayError(gatewayID, 0, err)
 		return
 	}
+	configDuration := time.Since(phaseStartedAt)
 
 	spec := GatewayStartSpec{
 		GatewayID:     gatewayID,
@@ -192,22 +202,29 @@ func (m *GatewayManager) startGatewayInBackground(gatewayID string, req CreateGa
 		Command:       append([]string(nil), m.cfg.GatewayCommand...),
 		Env:           m.profile().GatewayEnv(os.Environ(), m.cfg, req, workspacePath, port),
 	}
+	phaseStartedAt = time.Now()
 	process, err := m.starter.StartGateway(context.Background(), spec)
 	if err != nil {
+		log.Printf("runtime-agent gateway startup failed: gateway_id=%s instance_id=%d phase=start_process phase_ms=%d total_ms=%d error=%v", gatewayID, req.InstanceID, time.Since(phaseStartedAt).Milliseconds(), time.Since(startedAt).Milliseconds(), err)
 		m.markGatewayError(gatewayID, 0, fmt.Errorf("%w: %v", ErrGatewayStartFailed, err))
 		return
 	}
+	processStartDuration := time.Since(phaseStartedAt)
 	if !m.attachGatewayProcess(gatewayID, process) {
 		m.stopProcessAsync(process)
 		return
 	}
 
+	phaseStartedAt = time.Now()
 	if err := m.health.WaitReady(context.Background(), spec); err != nil {
+		log.Printf("runtime-agent gateway startup failed: gateway_id=%s instance_id=%d phase=wait_ready phase_ms=%d total_ms=%d error=%v", gatewayID, req.InstanceID, time.Since(phaseStartedAt).Milliseconds(), time.Since(startedAt).Milliseconds(), err)
 		m.stopProcessAsync(process)
 		m.markGatewayError(gatewayID, process.PID, fmt.Errorf("%w: %v", ErrGatewayStartFailed, err))
 		return
 	}
+	healthDuration := time.Since(phaseStartedAt)
 	m.markGatewayRunning(gatewayID, req, process.PID)
+	log.Printf("runtime-agent gateway ready: gateway_id=%s instance_id=%d port=%d pid=%d total_ms=%d prepare_ms=%d config_ms=%d process_ms=%d health_ms=%d", gatewayID, req.InstanceID, port, process.PID, time.Since(startedAt).Milliseconds(), prepareDuration.Milliseconds(), configDuration.Milliseconds(), processStartDuration.Milliseconds(), healthDuration.Milliseconds())
 	if process.Done != nil {
 		go m.watchGatewayProcess(gatewayID, process.Done)
 	}
@@ -266,6 +283,10 @@ func (m *GatewayManager) GatewayStates() []GatewayState {
 		states = append(states, record.state)
 	}
 	return states
+}
+
+func (m *GatewayManager) GatewayStateChanges() <-chan struct{} {
+	return m.changes
 }
 
 func (m *GatewayManager) Health() error {
@@ -365,6 +386,7 @@ func (m *GatewayManager) detachGatewayLocked(id string) ManagedProcess {
 	}
 	m.ports.Release(record.state.Port)
 	delete(m.gateways, id)
+	m.notifyGatewayStateChangedLocked()
 	return record.process
 }
 
@@ -396,6 +418,7 @@ func (m *GatewayManager) markGatewayRunning(id string, req CreateGatewayRequest,
 	record.state.ErrorMessage = resourceLimitDegradation(req)
 	record.state.HealthAt = now
 	record.state.UpdatedAt = now
+	m.notifyGatewayStateChangedLocked()
 }
 
 func (m *GatewayManager) markGatewayError(id string, pid int, cause error) {
@@ -415,6 +438,7 @@ func (m *GatewayManager) markGatewayError(id string, pid int, cause error) {
 	record.state.ErrorMessage = cause.Error()
 	record.state.HealthAt = now
 	record.state.UpdatedAt = now
+	m.notifyGatewayStateChangedLocked()
 }
 
 func (m *GatewayManager) watchGatewayProcess(id string, done <-chan error) {
@@ -433,10 +457,19 @@ func (m *GatewayManager) watchGatewayProcess(id string, done <-chan error) {
 	if err != nil {
 		record.state.State = "error"
 		record.state.ErrorMessage = err.Error()
+		m.notifyGatewayStateChangedLocked()
 		return
 	}
 	record.state.State = "stopped"
 	record.state.ErrorMessage = ""
+	m.notifyGatewayStateChangedLocked()
+}
+
+func (m *GatewayManager) notifyGatewayStateChangedLocked() {
+	select {
+	case m.changes <- struct{}{}:
+	default:
+	}
 }
 
 func (m *GatewayManager) stopProcessAsync(process ManagedProcess) {

--- a/clawmanager-agent/internal/gateway/manager.go
+++ b/clawmanager-agent/internal/gateway/manager.go
@@ -501,6 +501,7 @@ func OpenClawGatewayEnv(base []string, cfg Config, req CreateGatewayRequest, wor
 	env = setEnv(env, "CLAWMANAGER_USER_ID", strconv.Itoa(req.UserID))
 	env = setEnv(env, "CLAWMANAGER_RUNTIME_TYPE", cfg.RuntimeType)
 	env = setEnv(env, "CLAWMANAGER_WORKSPACE_PATH", workspacePath)
+	env = setEnv(env, "CLAWMANAGER_AGENT_PERSISTENT_DIR", filepath.Join(workspacePath, "home", ".openclaw"))
 	env = setEnv(env, "CLAWMANAGER_GATEWAY_PORT", strconv.Itoa(port))
 	env = setEnv(env, "HOME", filepath.Join(workspacePath, "home"))
 	env = setEnv(env, "HOST", "0.0.0.0")

--- a/clawmanager-agent/internal/gateway/manager.go
+++ b/clawmanager-agent/internal/gateway/manager.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -105,15 +106,28 @@ func (m *GatewayManager) CreateGateway(_ context.Context, req CreateGatewayReque
 
 	capacity := m.effectiveCapacityLocked()
 	if capacity <= 0 || m.usedSlotsLocked() >= capacity {
+		var reserveErr error = ErrNoFreePort
+		if req.GatewayPort > 0 {
+			reserveErr = fmt.Errorf("requested gateway port %d is unavailable: capacity exhausted: %w", req.GatewayPort, ErrNoFreePort)
+			log.Printf("runtime-agent reserve requested gateway port failed: instance_id=%d generation=%d gateway_port=%d: %v", req.InstanceID, req.Generation, req.GatewayPort, reserveErr)
+		}
 		m.mu.Unlock()
 		for _, process := range oldProcesses {
 			m.stopProcessAsync(process)
 		}
-		return CreateGatewayResponse{}, ErrNoFreePort
+		return CreateGatewayResponse{}, reserveErr
 	}
 
-	port, err := m.ports.Reserve(req.InstanceID, req.Generation, rng)
+	var port int
+	if req.GatewayPort > 0 {
+		port, err = m.ports.ReserveExact(req.InstanceID, req.Generation, req.GatewayPort)
+	} else {
+		port, err = m.ports.Reserve(req.InstanceID, req.Generation, rng)
+	}
 	if err != nil {
+		if req.GatewayPort > 0 {
+			log.Printf("runtime-agent reserve requested gateway port failed: instance_id=%d generation=%d gateway_port=%d: %v", req.InstanceID, req.Generation, req.GatewayPort, err)
+		}
 		m.mu.Unlock()
 		for _, process := range oldProcesses {
 			m.stopProcessAsync(process)
@@ -157,7 +171,7 @@ func (m *GatewayManager) startGatewayInBackground(gatewayID string, req CreateGa
 		m.markGatewayError(gatewayID, 0, err)
 		return
 	}
-	if err := m.profile().WriteGatewayConfig(m.cfg, req, workspacePath); err != nil {
+	if err := m.profile().WriteGatewayConfig(m.cfg, req, workspacePath, port); err != nil {
 		m.markGatewayError(gatewayID, 0, err)
 		return
 	}

--- a/clawmanager-agent/internal/gateway/ports.go
+++ b/clawmanager-agent/internal/gateway/ports.go
@@ -77,6 +77,35 @@ func (a *PortAllocator) Reserve(instanceID, generation int, rng PortRange) (int,
 	return 0, ErrNoFreePort
 }
 
+// ReserveExact reserves the supplied primary gateway port and its associated
+// port block. It intentionally does not constrain the port to a locally
+// configured range: the control plane owns exact port assignment.
+func (a *PortAllocator) ReserveExact(instanceID, generation, port int) (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	blockSize := a.blockSize
+	if blockSize <= 0 {
+		blockSize = 1
+	}
+	if port <= 0 || port > 65535 || port+blockSize-1 > 65535 {
+		return 0, fmt.Errorf("invalid requested gateway port %d", port)
+	}
+	if !a.blockAvailableLocked(port, blockSize) {
+		return 0, fmt.Errorf("requested gateway port %d is unavailable: %w", port, ErrNoFreePort)
+	}
+
+	allocation := portAllocation{
+		InstanceID:  instanceID,
+		Generation:  generation,
+		PrimaryPort: port,
+		Status:      portReserved,
+	}
+	for offset := 0; offset < blockSize; offset++ {
+		a.ports[port+offset] = allocation
+	}
+	return port, nil
+}
 func (a *PortAllocator) blockAvailableLocked(port, blockSize int) bool {
 	for offset := 0; offset < blockSize; offset++ {
 		member := port + offset

--- a/clawmanager-agent/internal/gateway/ports.go
+++ b/clawmanager-agent/internal/gateway/ports.go
@@ -20,6 +20,15 @@ type portAllocation struct {
 	Status      portStatus
 }
 
+type portBlockConflict struct {
+	Port   int
+	Reason string
+}
+
+func (c portBlockConflict) Error() string {
+	return fmt.Sprintf("port block member %d is already %s", c.Port, c.Reason)
+}
+
 type PortAllocator struct {
 	mu          sync.Mutex
 	ports       map[int]portAllocation
@@ -60,7 +69,7 @@ func (a *PortAllocator) Reserve(instanceID, generation int, rng PortRange) (int,
 	}
 	lastPrimaryPort := rng.End - blockSize + 1
 	for port := rng.Start; port <= lastPrimaryPort; port += blockSize {
-		if !a.blockAvailableLocked(port, blockSize) {
+		if conflict := a.blockConflictLocked(port, blockSize); conflict != nil {
 			continue
 		}
 		allocation := portAllocation{
@@ -91,8 +100,8 @@ func (a *PortAllocator) ReserveExact(instanceID, generation, port int) (int, err
 	if port <= 0 || port > 65535 || port+blockSize-1 > 65535 {
 		return 0, fmt.Errorf("invalid requested gateway port %d", port)
 	}
-	if !a.blockAvailableLocked(port, blockSize) {
-		return 0, fmt.Errorf("requested gateway port %d is unavailable: %w", port, ErrNoFreePort)
+	if conflict := a.blockConflictLocked(port, blockSize); conflict != nil {
+		return 0, fmt.Errorf("requested gateway port %d is unavailable: %w: %w", port, conflict, ErrNoFreePort)
 	}
 
 	allocation := portAllocation{
@@ -106,17 +115,18 @@ func (a *PortAllocator) ReserveExact(instanceID, generation, port int) (int, err
 	}
 	return port, nil
 }
-func (a *PortAllocator) blockAvailableLocked(port, blockSize int) bool {
+
+func (a *PortAllocator) blockConflictLocked(port, blockSize int) *portBlockConflict {
 	for offset := 0; offset < blockSize; offset++ {
 		member := port + offset
 		if _, exists := a.ports[member]; exists {
-			return false
+			return &portBlockConflict{Port: member, Reason: "reserved by AgentRuntime"}
 		}
 		if a.isListening(member) {
-			return false
+			return &portBlockConflict{Port: member, Reason: "listening"}
 		}
 	}
-	return true
+	return nil
 }
 
 func (a *PortAllocator) Commit(instanceID, generation, port int) {

--- a/clawmanager-agent/internal/gateway/ports_exact_test.go
+++ b/clawmanager-agent/internal/gateway/ports_exact_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -17,10 +18,36 @@ func TestPortAllocatorReservesExactPortAndReleasesItsBlock(t *testing.T) {
 	if _, err := alloc.ReserveExact(102, 7, 20004); !errors.Is(err, ErrNoFreePort) || !strings.Contains(err.Error(), "20004") {
 		t.Fatalf("overlapping ReserveExact() error = %v, want diagnostic ErrNoFreePort", err)
 	}
+	if _, err := alloc.ReserveExact(102, 7, 20001); !errors.Is(err, ErrNoFreePort) || !strings.Contains(err.Error(), "20003") || !strings.Contains(err.Error(), "reserved by AgentRuntime") {
+		t.Fatalf("overlapping ReserveExact() error = %v, want diagnostic with reserved block member 20003", err)
+	}
 
 	alloc.Release(20003)
 	port, err = alloc.ReserveExact(102, 7, 20003)
 	if err != nil || port != 20003 {
 		t.Fatalf("ReserveExact() after release = %d, %v; want 20003, nil", port, err)
+	}
+}
+
+func TestPortAllocatorReserveExactReportsListeningBlockMember(t *testing.T) {
+	for _, listeningPort := range []int{20051, 20052, 20053} {
+		t.Run(strconv.Itoa(listeningPort), func(t *testing.T) {
+			alloc := NewPortAllocator(func(port int) bool { return port == listeningPort })
+			alloc.SetBlockSize(3)
+
+			_, err := alloc.ReserveExact(415, 1, 20051)
+			if !errors.Is(err, ErrNoFreePort) {
+				t.Fatalf("ReserveExact() error = %v, want ErrNoFreePort", err)
+			}
+			if !strings.Contains(err.Error(), "requested gateway port 20051") {
+				t.Fatalf("ReserveExact() error = %q, want requested gateway port", err)
+			}
+			if !strings.Contains(err.Error(), "port block member "+strconv.Itoa(listeningPort)) {
+				t.Fatalf("ReserveExact() error = %q, want conflict member %d", err, listeningPort)
+			}
+			if !strings.Contains(err.Error(), "already listening") {
+				t.Fatalf("ReserveExact() error = %q, want listening reason", err)
+			}
+		})
 	}
 }

--- a/clawmanager-agent/internal/gateway/ports_exact_test.go
+++ b/clawmanager-agent/internal/gateway/ports_exact_test.go
@@ -1,0 +1,26 @@
+package gateway
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPortAllocatorReservesExactPortAndReleasesItsBlock(t *testing.T) {
+	alloc := NewPortAllocator(func(int) bool { return false })
+	alloc.SetBlockSize(3)
+
+	port, err := alloc.ReserveExact(101, 7, 20003)
+	if err != nil || port != 20003 {
+		t.Fatalf("ReserveExact() = %d, %v; want 20003, nil", port, err)
+	}
+	if _, err := alloc.ReserveExact(102, 7, 20004); !errors.Is(err, ErrNoFreePort) || !strings.Contains(err.Error(), "20004") {
+		t.Fatalf("overlapping ReserveExact() error = %v, want diagnostic ErrNoFreePort", err)
+	}
+
+	alloc.Release(20003)
+	port, err = alloc.ReserveExact(102, 7, 20003)
+	if err != nil || port != 20003 {
+		t.Fatalf("ReserveExact() after release = %d, %v; want 20003, nil", port, err)
+	}
+}

--- a/clawmanager-agent/internal/gateway/ports_test.go
+++ b/clawmanager-agent/internal/gateway/ports_test.go
@@ -1,6 +1,9 @@
 package gateway
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestPortAllocatorReservesCommitsAndReleasesPorts(t *testing.T) {
 	alloc := NewPortAllocator(func(int) bool { return false })
@@ -96,5 +99,48 @@ func TestPortAllocatorSkipsListeningPortsInsidePortBlock(t *testing.T) {
 	}
 	if port != 32003 {
 		t.Fatalf("Reserve = %d, want first block without listening sidecar port 32003", port)
+	}
+}
+
+func TestPortAllocatorConcurrentReserveReturnsUniquePortBlocks(t *testing.T) {
+	alloc := NewPortAllocator(func(int) bool { return false })
+	alloc.SetBlockSize(3)
+	rng := PortRange{Start: 40000, End: 40299}
+
+	const workers = 100
+	var wg sync.WaitGroup
+	results := make(chan int, workers)
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			port, err := alloc.Reserve(1000+index, 7, rng)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- port
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	seen := map[int]bool{}
+	for port := range results {
+		if seen[port] {
+			t.Fatalf("duplicate primary port reserved: %d", port)
+		}
+		seen[port] = true
+	}
+	if len(seen) != workers {
+		t.Fatalf("reserved %d unique ports, want %d", len(seen), workers)
+	}
+	if used := len(alloc.ListUsed()); used != workers*3 {
+		t.Fatalf("reserved block members = %d, want %d", used, workers*3)
 	}
 }

--- a/clawmanager-agent/internal/gateway/profile.go
+++ b/clawmanager-agent/internal/gateway/profile.go
@@ -48,7 +48,7 @@ func (openClawCompatProfile) PrepareWorkspace(cfg Config, req CreateGatewayReque
 	return nil
 }
 
-func (openClawCompatProfile) WriteGatewayConfig(cfg Config, req CreateGatewayRequest, workspacePath string) error {
+func (openClawCompatProfile) WriteGatewayConfig(cfg Config, req CreateGatewayRequest, workspacePath string, port int) error {
 	return nil
 }
 

--- a/clawmanager-agent/internal/gateway/types.go
+++ b/clawmanager-agent/internal/gateway/types.go
@@ -79,7 +79,7 @@ type RuntimeProfile interface {
 	GatewayCommand(authMode string) []string
 	GatewayEnv(base []string, cfg Config, req CreateGatewayRequest, workspacePath string, port int) []string
 	PrepareWorkspace(cfg Config, req CreateGatewayRequest, workspacePath string) error
-	WriteGatewayConfig(cfg Config, req CreateGatewayRequest, workspacePath string) error
+	WriteGatewayConfig(cfg Config, req CreateGatewayRequest, workspacePath string, port int) error
 	HealthChecker(cfg Config) GatewayHealthChecker
 }
 
@@ -93,6 +93,7 @@ type CreateGatewayRequest struct {
 	UserID        int               `json:"user_id"`
 	AgentType     string            `json:"agent_type"`
 	WorkspacePath string            `json:"workspace_path"`
+	GatewayPort   int               `json:"gateway_port,omitempty"`
 	PortRange     PortRange         `json:"port_range"`
 	UID           int               `json:"uid"`
 	GID           int               `json:"gid"`

--- a/clawmanager-agent/internal/runtime/generic/profile.go
+++ b/clawmanager-agent/internal/runtime/generic/profile.go
@@ -59,7 +59,7 @@ func (p Profile) PrepareWorkspace(cfg gateway.Config, req gateway.CreateGatewayR
 	return nil
 }
 
-func (p Profile) WriteGatewayConfig(gateway.Config, gateway.CreateGatewayRequest, string) error {
+func (p Profile) WriteGatewayConfig(gateway.Config, gateway.CreateGatewayRequest, string, int) error {
 	return nil
 }
 

--- a/clawmanager-agent/internal/runtime/hermes/profile.go
+++ b/clawmanager-agent/internal/runtime/hermes/profile.go
@@ -84,7 +84,7 @@ func (p Profile) PrepareWorkspace(cfg gateway.Config, req gateway.CreateGatewayR
 	return nil
 }
 
-func (p Profile) WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string) error {
+func (p Profile) WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string, _ int) error {
 	return WriteGatewayConfig(cfg, req, workspacePath)
 }
 

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -18,6 +18,8 @@ const openClawAutoProviderName = "auto"
 const openClawRedisTeamPluginID = "redis-team"
 const openClawRedisTeamPluginDirEnv = "CLAWMANAGER_OPENCLAW_REDIS_TEAM_PLUGIN_DIR"
 const openClawBrowserExecutablePath = "/usr/bin/chromium"
+const openClawManagedBrowserProfile = "openclaw"
+const openClawManagedBrowserColor = "#FF4500"
 const openClawChannelsEnv = "CLAWMANAGER_OPENCLAW_CHANNELS_JSON"
 
 var openClawDefaultDeniedNodeCommands = []string{
@@ -52,8 +54,11 @@ var openClawEnvManagedChannelPlugins = map[string][]string{
 }
 
 func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string, port int) error {
-	if port <= 0 || port > 65535 {
+	if port <= 0 {
 		return fmt.Errorf("invalid gateway port %d", port)
+	}
+	if port > 65533 {
+		return fmt.Errorf("invalid gateway port %d: managed OpenClaw Lite port block exceeds 65535", port)
 	}
 	if err := gateway.WriteLiteTeamConfigJSON(req, workspacePath); err != nil {
 		return err
@@ -84,7 +89,7 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read openclaw config: %w", err)
 	}
-	configureManagedOpenClawBrowser(config)
+	configureManagedOpenClawBrowser(config, port)
 	mergeOpenClawLiteDefaults(config)
 	if err := mergeOpenClawChannelsFromRequest(config, req); err != nil {
 		return err
@@ -159,14 +164,20 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 
 // configureManagedOpenClawBrowser supplies the safe Lite runtime defaults that
 // are present in the image template without replacing an instance's explicit
-// browser choices. New pooled workspaces start from an empty config, so relying
-// on the image template alone leaves Browser unavailable for those instances.
-func configureManagedOpenClawBrowser(config map[string]any) {
+// browser choices. The managed local openclaw profile always receives the CDP
+// port allocated inside this gateway's 3-port block.
+func configureManagedOpenClawBrowser(config map[string]any, gatewayPort int) {
 	browser := ensureObject(config, "browser")
 	setDefaultObjectValue(browser, "enabled", true)
 	setDefaultObjectValue(browser, "executablePath", openClawBrowserExecutablePath)
 	setDefaultObjectValue(browser, "headless", true)
 	setDefaultObjectValue(browser, "noSandbox", true)
+
+	profiles := ensureObject(browser, "profiles")
+	profile := ensureObject(profiles, openClawManagedBrowserProfile)
+	profile["driver"] = "openclaw"
+	profile["cdpPort"] = gatewayPort + 1
+	setDefaultObjectValue(profile, "color", openClawManagedBrowserColor)
 }
 
 func setDefaultObjectValue(object map[string]any, key string, value any) {

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -19,7 +19,10 @@ const openClawRedisTeamPluginID = "redis-team"
 const openClawRedisTeamPluginDirEnv = "CLAWMANAGER_OPENCLAW_REDIS_TEAM_PLUGIN_DIR"
 const openClawBrowserExecutablePath = "/usr/bin/chromium"
 
-func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string) error {
+func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string, port int) error {
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid gateway port %d", port)
+	}
 	if err := gateway.WriteLiteTeamConfigJSON(req, workspacePath); err != nil {
 		return err
 	}
@@ -44,6 +47,7 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 	}
 	configureManagedOpenClawBrowser(config)
 
+	mergePlatformDefaults(config, port)
 	if teamEnabledFromRequest(req) {
 		if err := configureOpenClawRedisTeam(config, req, workspacePath); err != nil {
 			return err
@@ -125,6 +129,40 @@ func setDefaultObjectValue(object map[string]any, key string, value any) {
 		return
 	}
 	object[key] = value
+}
+
+func mergePlatformDefaults(config map[string]any, port int) {
+	gatewayConfig := ensureObject(config, "gateway")
+	gatewayConfig["port"] = port
+
+	cron := ensureObject(config, "cron")
+	cron["enabled"] = true
+	cron["maxConcurrentRuns"] = 2
+	runLog := ensureObject(cron, "runLog")
+	runLog["keepLines"] = 2000
+	runLog["maxBytes"] = "2mb"
+	cron["sessionRetention"] = "24h"
+
+	update := ensureObject(config, "update")
+	update["checkOnStart"] = false
+	auto := ensureObject(update, "auto")
+	auto["enabled"] = false
+
+	hooks := ensureObject(config, "hooks")
+	internal := ensureObject(hooks, "internal")
+	internal["enabled"] = true
+	entries := ensureObject(internal, "entries")
+	sessionMemory := ensureObject(entries, "session-memory")
+	sessionMemory["enabled"] = true
+	sessionMemory["messages"] = 50
+
+	session := ensureObject(config, "session")
+	reset := ensureObject(session, "reset")
+	reset["idleMinutes"] = 10080
+	reset["mode"] = "idle"
+	maintenance := ensureObject(session, "maintenance")
+	maintenance["maxEntries"] = 2000
+	maintenance["pruneAfter"] = "180d"
 }
 
 func configureOpenClawRedisTeam(config map[string]any, req gateway.CreateGatewayRequest, workspacePath string) error {

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -14,6 +14,7 @@ import (
 
 const openClawTrustedProxyUserHeader = "x-forwarded-prefix"
 const openClawTrustedProxyRequiredHeader = "x-forwarded-proto"
+const openClawTrustedProxyDefaultPassword = "9fb3edf4bf38bb834227d41fe9cc1196"
 const openClawAutoProviderName = "auto"
 const openClawRedisTeamPluginID = "redis-team"
 const openClawRedisTeamPluginDirEnv = "CLAWMANAGER_OPENCLAW_REDIS_TEAM_PLUGIN_DIR"
@@ -115,6 +116,9 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 	} else {
 		auth["mode"] = "trusted-proxy"
 		delete(auth, "token")
+		if strings.TrimSpace(configStringValue(auth["password"])) == "" {
+			auth["password"] = openClawTrustedProxyDefaultPassword
+		}
 		trustedProxy := ensureObject(auth, "trustedProxy")
 		trustedProxy["userHeader"] = openClawTrustedProxyUserHeader
 		trustedProxy["requiredHeaders"] = []string{openClawTrustedProxyRequiredHeader}

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -18,6 +18,16 @@ const openClawAutoProviderName = "auto"
 const openClawRedisTeamPluginID = "redis-team"
 const openClawRedisTeamPluginDirEnv = "CLAWMANAGER_OPENCLAW_REDIS_TEAM_PLUGIN_DIR"
 const openClawBrowserExecutablePath = "/usr/bin/chromium"
+const openClawChannelsEnv = "CLAWMANAGER_OPENCLAW_CHANNELS_JSON"
+
+var openClawEnvManagedChannelPlugins = map[string][]string{
+	"dingtalk":              {"dingtalk-connector"},
+	"dingtalk-connector":    {"dingtalk-connector"},
+	"feishu":                {"feishu"},
+	"lark":                  {"feishu"},
+	"wecom":                 {"wecom-openclaw-plugin"},
+	"wecom-openclaw-plugin": {"wecom-openclaw-plugin"},
+}
 
 func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string, port int) error {
 	if port <= 0 || port > 65535 {
@@ -32,9 +42,16 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 	}
 	cfg = resolvedCfg
 
-	configPath := filepath.Join(workspacePath, "home", ".openclaw", "openclaw.json")
+	instancePaths, err := resolveOpenClawInstancePaths(req, workspacePath)
+	if err != nil {
+		return err
+	}
+	configPath := filepath.Join(instancePaths.Persistent, "openclaw.json")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
 		return fmt.Errorf("create openclaw config dir: %w", err)
+	}
+	if err := seedOpenClawPluginRuntime(req, instancePaths.Persistent); err != nil {
+		return err
 	}
 
 	config := map[string]any{}
@@ -46,8 +63,13 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 		return fmt.Errorf("read openclaw config: %w", err)
 	}
 	configureManagedOpenClawBrowser(config)
+	if err := mergeOpenClawChannelsFromRequest(config, req); err != nil {
+		return err
+	}
 
 	mergePlatformDefaults(config, port)
+	agentDefaults := ensureObject(ensureObject(config, "agents"), "defaults")
+	agentDefaults["workspace"] = filepath.ToSlash(instancePaths.OpenClawWorkspace)
 	if teamEnabledFromRequest(req) {
 		if err := configureOpenClawRedisTeam(config, req, workspacePath); err != nil {
 			return err
@@ -129,6 +151,67 @@ func setDefaultObjectValue(object map[string]any, key string, value any) {
 		return
 	}
 	object[key] = value
+}
+
+func mergeOpenClawChannelsFromRequest(config map[string]any, req gateway.CreateGatewayRequest) error {
+	raw, ok := requestEnvValue(req, openClawChannelsEnv)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	var payload any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return fmt.Errorf("parse %s: %w", openClawChannelsEnv, err)
+	}
+	channelsPayload, ok := payload.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must be a JSON object", openClawChannelsEnv)
+	}
+
+	channels := ensureObject(config, "channels")
+	for name, channel := range channelsPayload {
+		channels[name] = channel
+	}
+	reconcileOpenClawChannelPlugins(config, channelsPayload)
+	applyOpenClawChannelDefaults(config, channelsPayload)
+	return nil
+}
+
+func applyOpenClawChannelDefaults(config map[string]any, channelsPayload map[string]any) {
+	if _, ok := channelsPayload["dingtalk"]; !ok {
+		if _, ok := channelsPayload["dingtalk-connector"]; !ok {
+			return
+		}
+	}
+
+	messages := ensureObject(config, "messages")
+	groupChat := ensureObject(messages, "groupChat")
+	if value, ok := groupChat["visibleReplies"].(string); ok && strings.TrimSpace(value) != "" {
+		return
+	}
+	groupChat["visibleReplies"] = "automatic"
+}
+
+func reconcileOpenClawChannelPlugins(config map[string]any, channelsPayload map[string]any) {
+	plugins := ensureObject(config, "plugins")
+	entries := ensureObject(plugins, "entries")
+	enabledPlugins := map[string]struct{}{}
+	for channelID := range channelsPayload {
+		for _, pluginID := range openClawEnvManagedChannelPlugins[channelID] {
+			enabledPlugins[pluginID] = struct{}{}
+		}
+	}
+	managedPlugins := map[string]struct{}{}
+	for _, pluginIDs := range openClawEnvManagedChannelPlugins {
+		for _, pluginID := range pluginIDs {
+			managedPlugins[pluginID] = struct{}{}
+		}
+	}
+	for pluginID := range managedPlugins {
+		entry := ensureObject(entries, pluginID)
+		_, enabled := enabledPlugins[pluginID]
+		entry["enabled"] = enabled
+	}
 }
 
 func mergePlatformDefaults(config map[string]any, port int) {
@@ -257,6 +340,14 @@ func seedOpenClawRedisTeamPlugin(req gateway.CreateGatewayRequest, workspacePath
 	}
 	extensionsDir := filepath.Join(workspacePath, "home", ".openclaw", "extensions")
 	target := filepath.Join(extensionsDir, openClawRedisTeamPluginID)
+	if _, err := os.Stat(filepath.Join(target, "openclaw.plugin.json")); err == nil {
+		if err := chownTree(target, req.UID, req.GID); err != nil {
+			return fmt.Errorf("chown redis-team plugin: %w", err)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat redis-team plugin target: %w", err)
+	}
 	if err := copyDir(source, target); err != nil {
 		return fmt.Errorf("seed redis-team plugin: %w", err)
 	}
@@ -314,9 +405,19 @@ func copyDir(source, target string) error {
 	for _, entry := range entries {
 		srcPath := filepath.Join(source, entry.Name())
 		dstPath := filepath.Join(target, entry.Name())
-		entryInfo, err := entry.Info()
+		entryInfo, err := os.Lstat(srcPath)
 		if err != nil {
 			return err
+		}
+		if entryInfo.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.Symlink(linkTarget, dstPath); err != nil {
+				return err
+			}
+			continue
 		}
 		if entryInfo.IsDir() {
 			if err := copyDir(srcPath, dstPath); err != nil {
@@ -358,9 +459,12 @@ func copyRegularFile(source, target string, mode os.FileMode) error {
 }
 
 func chownTree(root string, uid, gid int) error {
-	return filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
 		}
 		return gateway.ChownWorkspace(path, uid, gid)
 	})

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -20,6 +20,28 @@ const openClawRedisTeamPluginDirEnv = "CLAWMANAGER_OPENCLAW_REDIS_TEAM_PLUGIN_DI
 const openClawBrowserExecutablePath = "/usr/bin/chromium"
 const openClawChannelsEnv = "CLAWMANAGER_OPENCLAW_CHANNELS_JSON"
 
+var openClawDefaultDeniedNodeCommands = []string{
+	"camera.snap",
+	"camera.clip",
+	"screen.record",
+	"contacts.add",
+	"calendar.add",
+	"reminders.add",
+	"sms.send",
+}
+
+var openClawDefaultDisabledPlugins = []string{
+	"bonjour",
+	"acpx",
+	"browser",
+	"phone-control",
+	"talk-voice",
+	"device-pair",
+	"dingtalk-connector",
+	"wecom-openclaw-plugin",
+	"redis-team",
+}
+
 var openClawEnvManagedChannelPlugins = map[string][]string{
 	"dingtalk":              {"dingtalk-connector"},
 	"dingtalk-connector":    {"dingtalk-connector"},
@@ -63,6 +85,7 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 		return fmt.Errorf("read openclaw config: %w", err)
 	}
 	configureManagedOpenClawBrowser(config)
+	mergeOpenClawLiteDefaults(config)
 	if err := mergeOpenClawChannelsFromRequest(config, req); err != nil {
 		return err
 	}
@@ -151,6 +174,69 @@ func setDefaultObjectValue(object map[string]any, key string, value any) {
 		return
 	}
 	object[key] = value
+}
+
+// mergeOpenClawLiteDefaults supplies the instance defaults that Pro receives
+// from /defaults/.openclaw/openclaw.json. Lite workspaces start with an empty
+// config, so these defaults must be added when the instance is created.
+//
+// Values are only filled when absent so recreating an existing Lite instance
+// does not discard explicit user choices. Environment-managed model, channel,
+// Team, gateway port, and authentication settings are applied afterwards.
+func mergeOpenClawLiteDefaults(config map[string]any) {
+	models := ensureObject(config, "models")
+	setDefaultObjectValue(models, "mode", "merge")
+
+	agentDefaults := ensureObject(ensureObject(config, "agents"), "defaults")
+	memorySearch := ensureObject(agentDefaults, "memorySearch")
+	setDefaultObjectValue(memorySearch, "enabled", true)
+	setDefaultObjectValue(memorySearch, "provider", "none")
+
+	compaction := ensureObject(agentDefaults, "compaction")
+	setDefaultObjectValue(compaction, "mode", "default")
+	setDefaultObjectValue(compaction, "reserveTokens", 32768)
+	setDefaultObjectValue(compaction, "reserveTokensFloor", 20000)
+	setDefaultObjectValue(compaction, "keepRecentTokens", 30000)
+	setDefaultObjectValue(compaction, "maxHistoryShare", 0.65)
+	setDefaultObjectValue(compaction, "notifyUser", true)
+	memoryFlush := ensureObject(compaction, "memoryFlush")
+	setDefaultObjectValue(memoryFlush, "enabled", true)
+
+	setDefaultObjectValue(agentDefaults, "maxConcurrent", 4)
+	subagents := ensureObject(agentDefaults, "subagents")
+	setDefaultObjectValue(subagents, "maxConcurrent", 8)
+
+	tools := ensureObject(config, "tools")
+	setDefaultObjectValue(tools, "profile", "full")
+
+	commands := ensureObject(config, "commands")
+	setDefaultObjectValue(commands, "native", "auto")
+	setDefaultObjectValue(commands, "nativeSkills", "auto")
+	setDefaultObjectValue(commands, "restart", true)
+	setDefaultObjectValue(commands, "ownerDisplay", "raw")
+
+	messages := ensureObject(config, "messages")
+	groupChat := ensureObject(messages, "groupChat")
+	setDefaultObjectValue(groupChat, "visibleReplies", "automatic")
+
+	gatewayConfig := ensureObject(config, "gateway")
+	setDefaultObjectValue(gatewayConfig, "mode", "local")
+	tailscale := ensureObject(gatewayConfig, "tailscale")
+	setDefaultObjectValue(tailscale, "mode", "off")
+	setDefaultObjectValue(tailscale, "resetOnExit", false)
+	nodes := ensureObject(gatewayConfig, "nodes")
+	nodes["denyCommands"] = appendUniqueStringArray(nodes["denyCommands"], openClawDefaultDeniedNodeCommands...)
+
+	entries := ensureObject(ensureObject(config, "plugins"), "entries")
+	for _, pluginID := range openClawDefaultDisabledPlugins {
+		entry := ensureObject(entries, pluginID)
+		setDefaultObjectValue(entry, "enabled", false)
+	}
+	memoryCore := ensureObject(entries, "memory-core")
+	dreaming := ensureObject(ensureObject(memoryCore, "config"), "dreaming")
+	setDefaultObjectValue(dreaming, "enabled", true)
+	setDefaultObjectValue(dreaming, "frequency", "0 3 * * *")
+	setDefaultObjectValue(dreaming, "timezone", "Asia/Shanghai")
 }
 
 func mergeOpenClawChannelsFromRequest(config map[string]any, req gateway.CreateGatewayRequest) error {

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -32,6 +32,7 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 	    "trustedProxies": ["127.0.0.1"],
 	    "keep": "value"
 	  },
+	  "cron": {"custom": "keep"},
 	  "agents": {"defaults": {"model": "auto/gpt-4.1"}}
 	}`)
 	if err := os.WriteFile(configPath, existing, 0o644); err != nil {
@@ -49,7 +50,7 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 		LLMAPIKeySet:    true,
 		LLMModelIDs:     []string{"gpt-5.5", "gpt-5.5-mini"},
 	}
-	if err := WriteGatewayConfig(cfg, req, workspace); err != nil {
+	if err := WriteGatewayConfig(cfg, req, workspace, 20003); err != nil {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 
@@ -63,6 +64,9 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 	}
 
 	gateway := objectAt(t, merged, "gateway")
+	if gateway["port"] != float64(20003) {
+		t.Fatalf("gateway.port = %#v, want 20003", gateway["port"])
+	}
 	auth := objectAt(t, gateway, "auth")
 	if auth["mode"] != "trusted-proxy" {
 		t.Fatalf("gateway.auth.mode = %#v, want trusted-proxy", auth["mode"])
@@ -160,6 +164,10 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 	if got := modelIDSet(providerModels); len(got) != 2 || !got["gpt-5.5"] || !got["gpt-5.5-mini"] {
 		t.Fatalf("models.providers.auto.models = %#v, want injected model ids", providerModels)
 	}
+	assertPlatformDefaults(t, merged)
+	if objectAt(t, merged, "cron")["custom"] != "keep" {
+		t.Fatalf("cron.custom was not preserved")
+	}
 	if runtime.GOOS != "windows" {
 		info, err := os.Stat(configPath)
 		if err != nil {
@@ -249,7 +257,7 @@ func TestWriteOpenClawGatewayConfigUsesRequestEnvironmentLLMOverrides(t *testing
 	}
 	cfg := Config{GatewayAuthMode: "trusted-proxy"}
 
-	if err := WriteGatewayConfig(cfg, req, workspace); err != nil {
+	if err := WriteGatewayConfig(cfg, req, workspace, 20003); err != nil {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 
@@ -286,7 +294,7 @@ func TestWriteOpenClawGatewayConfigWritesLiteTeamConfigJSON(t *testing.T) {
 		},
 	}
 
-	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace); err != nil {
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 
@@ -340,7 +348,7 @@ func TestWriteOpenClawGatewayConfigEnablesRedisTeamForLiteTeam(t *testing.T) {
 		},
 	}
 
-	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace); err != nil {
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/iamlovingit/clawmanager-agent/internal/gateway"
@@ -190,7 +191,7 @@ func TestWriteOpenClawGatewayConfigCompletesPartialBrowserConfig(t *testing.T) {
 	}
 
 	req := CreateGatewayRequest{InstanceID: 64, UserID: 45, UID: 200064, GID: 200064}
-	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace); err != nil {
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 
@@ -219,7 +220,7 @@ func TestWriteOpenClawGatewayConfigPreservesExplicitBrowserConfig(t *testing.T) 
 	}
 
 	req := CreateGatewayRequest{InstanceID: 65, UserID: 45, UID: 200065, GID: 200065}
-	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace); err != nil {
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 
@@ -277,6 +278,222 @@ func TestWriteOpenClawGatewayConfigUsesRequestEnvironmentLLMOverrides(t *testing
 	model := objectAt(t, defaults, "model")
 	if model["primary"] != "auto/auto" {
 		t.Fatalf("agents.defaults.model.primary = %#v, want first request model", model["primary"])
+	}
+}
+
+func TestWriteOpenClawGatewayConfigMergesRequestChannelsIntoWorkspaceConfig(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-70")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{
+  "channels": {
+    "discord": {"enabled": true},
+    "telegram": {"enabled": false}
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	req := CreateGatewayRequest{
+		InstanceID: 70,
+		UserID:     45,
+		UID:        200070,
+		GID:        200070,
+		Environment: map[string]string{
+			"CLAWMANAGER_OPENCLAW_CHANNELS_JSON": `{"telegram":{"enabled":true},"feishu":{"enabled":true}}`,
+		},
+	}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read merged config: %v", err)
+	}
+	var merged map[string]any
+	if err := json.Unmarshal(data, &merged); err != nil {
+		t.Fatalf("parse merged config: %v", err)
+	}
+	channels := objectAt(t, merged, "channels")
+	if objectAt(t, channels, "telegram")["enabled"] != true {
+		t.Fatalf("channels.telegram.enabled = %#v, want true", objectAt(t, channels, "telegram")["enabled"])
+	}
+	if objectAt(t, channels, "feishu")["enabled"] != true {
+		t.Fatalf("channels.feishu.enabled = %#v, want true", objectAt(t, channels, "feishu")["enabled"])
+	}
+	if objectAt(t, channels, "discord")["enabled"] != true {
+		t.Fatalf("channels.discord.enabled = %#v, want preserved true", objectAt(t, channels, "discord")["enabled"])
+	}
+}
+
+func TestWriteOpenClawGatewayConfigReconcilesManagedChannelPluginEntries(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-72")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{
+  "plugins": {
+    "entries": {
+      "dingtalk-connector": {"enabled": false, "custom": "keep"},
+      "feishu": {"enabled": false},
+      "wecom-openclaw-plugin": {"enabled": true}
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	req := CreateGatewayRequest{
+		InstanceID: 72,
+		UserID:     45,
+		UID:        200072,
+		GID:        200072,
+		Environment: map[string]string{
+			"CLAWMANAGER_OPENCLAW_CHANNELS_JSON": `{"dingtalk":{},"feishu":{}}`,
+		},
+	}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read merged config: %v", err)
+	}
+	var merged map[string]any
+	if err := json.Unmarshal(data, &merged); err != nil {
+		t.Fatalf("parse merged config: %v", err)
+	}
+	entries := objectAt(t, objectAt(t, merged, "plugins"), "entries")
+	if got := objectAt(t, entries, "dingtalk-connector")["enabled"]; got != true {
+		t.Fatalf("plugins.entries.dingtalk-connector.enabled = %#v, want true", got)
+	}
+	if got := objectAt(t, entries, "feishu")["enabled"]; got != true {
+		t.Fatalf("plugins.entries.feishu.enabled = %#v, want true", got)
+	}
+	if got := objectAt(t, entries, "wecom-openclaw-plugin")["enabled"]; got != false {
+		t.Fatalf("plugins.entries.wecom-openclaw-plugin.enabled = %#v, want false", got)
+	}
+	if got := objectAt(t, entries, "dingtalk-connector")["custom"]; got != "keep" {
+		t.Fatalf("plugins.entries.dingtalk-connector.custom = %#v, want preserved value", got)
+	}
+	groupChat := objectAt(t, objectAt(t, merged, "messages"), "groupChat")
+	if got := groupChat["visibleReplies"]; got != "automatic" {
+		t.Fatalf("messages.groupChat.visibleReplies = %#v, want automatic", got)
+	}
+}
+
+func TestWriteOpenClawGatewayConfigPreservesExplicitDingTalkVisibleReplies(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-73")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{
+  "messages": {
+    "groupChat": {
+      "visibleReplies": "message_tool_only"
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	req := CreateGatewayRequest{
+		InstanceID: 73,
+		UserID:     45,
+		Environment: map[string]string{
+			"CLAWMANAGER_OPENCLAW_CHANNELS_JSON": `{"dingtalk-connector":{}}`,
+		},
+	}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read merged config: %v", err)
+	}
+	var merged map[string]any
+	if err := json.Unmarshal(data, &merged); err != nil {
+		t.Fatalf("parse merged config: %v", err)
+	}
+	groupChat := objectAt(t, objectAt(t, merged, "messages"), "groupChat")
+	if got := groupChat["visibleReplies"]; got != "message_tool_only" {
+		t.Fatalf("messages.groupChat.visibleReplies = %#v, want preserved explicit value", got)
+	}
+}
+
+func TestMergeOpenClawChannelsUsesEnvFallbackAndEnvironmentPriority(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		environment map[string]string
+		env         map[string]string
+		wantEnabled bool
+	}{
+		{
+			name: "Env fallback",
+			env: map[string]string{
+				openClawChannelsEnv: `{"telegram":{"enabled":false}}`,
+			},
+			wantEnabled: false,
+		},
+		{
+			name: "Environment priority",
+			environment: map[string]string{
+				openClawChannelsEnv: `{"telegram":{"enabled":true}}`,
+			},
+			env: map[string]string{
+				openClawChannelsEnv: `{"telegram":{"enabled":false}}`,
+			},
+			wantEnabled: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := map[string]any{}
+			req := CreateGatewayRequest{Environment: tc.environment, Env: tc.env}
+			if err := mergeOpenClawChannelsFromRequest(config, req); err != nil {
+				t.Fatalf("mergeOpenClawChannelsFromRequest() error = %v", err)
+			}
+			telegram := objectAt(t, objectAt(t, config, "channels"), "telegram")
+			if got := telegram["enabled"]; got != tc.wantEnabled {
+				t.Fatalf("channels.telegram.enabled = %#v, want %v", got, tc.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestWriteOpenClawGatewayConfigRejectsInvalidRequestChannelsPayload(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "array", payload: `[]`},
+		{name: "invalid json", payload: `{"telegram":`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-71")
+			req := CreateGatewayRequest{
+				InstanceID: 71,
+				UserID:     45,
+				UID:        200071,
+				GID:        200071,
+				Environment: map[string]string{
+					"CLAWMANAGER_OPENCLAW_CHANNELS_JSON": tc.payload,
+				},
+			}
+			err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003)
+			if err == nil {
+				t.Fatal("WriteGatewayConfig() error = nil, want invalid channels payload error")
+			}
+			if !strings.Contains(err.Error(), "CLAWMANAGER_OPENCLAW_CHANNELS_JSON") {
+				t.Fatalf("WriteGatewayConfig() error = %q, want environment name", err)
+			}
+		})
 	}
 }
 

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -230,6 +230,127 @@ func TestWriteOpenClawGatewayConfigPreservesExplicitBrowserConfig(t *testing.T) 
 	}
 }
 
+func TestWriteOpenClawGatewayConfigPreservesExplicitLiteDefaults(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-66")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	existing := []byte(`{
+  "models": {"mode": "replace"},
+  "agents": {
+    "defaults": {
+      "memorySearch": {"enabled": false, "provider": "local"},
+      "compaction": {
+        "mode": "safeguard",
+        "reserveTokens": 1024,
+        "reserveTokensFloor": 512,
+        "keepRecentTokens": 4096,
+        "maxHistoryShare": 0.5,
+        "notifyUser": false,
+        "memoryFlush": {"enabled": false}
+      },
+      "maxConcurrent": 2,
+      "subagents": {"maxConcurrent": 3}
+    }
+  },
+  "tools": {"profile": "minimal"},
+  "commands": {
+    "native": "off",
+    "nativeSkills": "off",
+    "restart": false,
+    "ownerDisplay": "friendly"
+  },
+  "messages": {"groupChat": {"visibleReplies": "message_tool_only"}},
+  "gateway": {
+    "mode": "remote",
+    "tailscale": {"mode": "on", "resetOnExit": true},
+    "nodes": {"denyCommands": ["custom.block"]}
+  },
+  "plugins": {
+    "entries": {
+      "bonjour": {"enabled": true},
+      "memory-core": {
+        "config": {
+          "dreaming": {
+            "enabled": false,
+            "frequency": "custom",
+            "timezone": "UTC"
+          }
+        }
+      }
+    }
+  }
+}`)
+	if err := os.WriteFile(configPath, existing, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	req := CreateGatewayRequest{InstanceID: 66, UserID: 45, UID: 200066, GID: 200066}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	merged := readOpenClawConfigForTest(t, configPath)
+	if got := objectAt(t, merged, "models")["mode"]; got != "replace" {
+		t.Fatalf("models.mode = %#v, want explicit replace preserved", got)
+	}
+	agentDefaults := objectAt(t, objectAt(t, merged, "agents"), "defaults")
+	memorySearch := objectAt(t, agentDefaults, "memorySearch")
+	if memorySearch["enabled"] != false || memorySearch["provider"] != "local" {
+		t.Fatalf("explicit memorySearch was overwritten: %#v", memorySearch)
+	}
+	compaction := objectAt(t, agentDefaults, "compaction")
+	if compaction["mode"] != "safeguard" ||
+		compaction["reserveTokens"] != float64(1024) ||
+		compaction["reserveTokensFloor"] != float64(512) ||
+		compaction["keepRecentTokens"] != float64(4096) ||
+		compaction["maxHistoryShare"] != 0.5 ||
+		compaction["notifyUser"] != false ||
+		objectAt(t, compaction, "memoryFlush")["enabled"] != false {
+		t.Fatalf("explicit compaction was overwritten: %#v", compaction)
+	}
+	if agentDefaults["maxConcurrent"] != float64(2) || objectAt(t, agentDefaults, "subagents")["maxConcurrent"] != float64(3) {
+		t.Fatalf("explicit agent concurrency was overwritten: %#v", agentDefaults)
+	}
+	if objectAt(t, merged, "tools")["profile"] != "minimal" {
+		t.Fatalf("explicit tools.profile was overwritten: %#v", objectAt(t, merged, "tools"))
+	}
+	commands := objectAt(t, merged, "commands")
+	if commands["native"] != "off" ||
+		commands["nativeSkills"] != "off" ||
+		commands["restart"] != false ||
+		commands["ownerDisplay"] != "friendly" {
+		t.Fatalf("explicit commands were overwritten: %#v", commands)
+	}
+	if objectAt(t, objectAt(t, merged, "messages"), "groupChat")["visibleReplies"] != "message_tool_only" {
+		t.Fatalf("explicit visibleReplies was overwritten")
+	}
+	gateway := objectAt(t, merged, "gateway")
+	if gateway["mode"] != "remote" {
+		t.Fatalf("gateway.mode = %#v, want explicit remote preserved", gateway["mode"])
+	}
+	tailscale := objectAt(t, gateway, "tailscale")
+	if tailscale["mode"] != "on" || tailscale["resetOnExit"] != true {
+		t.Fatalf("explicit gateway.tailscale was overwritten: %#v", tailscale)
+	}
+	deniedCommands, ok := objectAt(t, gateway, "nodes")["denyCommands"].([]any)
+	if !ok {
+		t.Fatalf("gateway.nodes.denyCommands = %#v, want array", objectAt(t, gateway, "nodes")["denyCommands"])
+	}
+	deniedSet := stringSet(deniedCommands)
+	if len(deniedSet) != len(openClawDefaultDeniedNodeCommands)+1 || !deniedSet["custom.block"] {
+		t.Fatalf("gateway.nodes.denyCommands = %#v, want custom command plus managed deny list", deniedCommands)
+	}
+	if objectAt(t, objectAt(t, objectAt(t, merged, "plugins"), "entries"), "bonjour")["enabled"] != true {
+		t.Fatalf("explicit bonjour enabled state was overwritten")
+	}
+	dreaming := objectAt(t, objectAt(t, objectAt(t, objectAt(t, objectAt(t, merged, "plugins"), "entries"), "memory-core"), "config"), "dreaming")
+	if dreaming["enabled"] != false || dreaming["frequency"] != "custom" || dreaming["timezone"] != "UTC" {
+		t.Fatalf("explicit memory-core dreaming config was overwritten: %#v", dreaming)
+	}
+}
+
 func readOpenClawConfigForTest(t *testing.T, configPath string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(configPath)

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -76,6 +76,9 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 	if _, ok := auth["token"]; ok {
 		t.Fatalf("gateway.auth.token was preserved in trusted-proxy mode")
 	}
+	if auth["password"] != "9fb3edf4bf38bb834227d41fe9cc1196" {
+		t.Fatalf("gateway.auth.password = %#v, want managed trusted-proxy password", auth["password"])
+	}
 	trustedProxy := objectAt(t, auth, "trustedProxy")
 	if trustedProxy["userHeader"] != "x-forwarded-prefix" {
 		t.Fatalf("gateway.auth.trustedProxy.userHeader = %#v, want x-forwarded-prefix", trustedProxy["userHeader"])
@@ -220,6 +223,27 @@ func TestWriteOpenClawGatewayConfigCompletesPartialBrowserConfig(t *testing.T) {
 	openclawProfile := objectAt(t, objectAt(t, browser, "profiles"), "openclaw")
 	if openclawProfile["cdpPort"] != float64(20004) {
 		t.Fatalf("browser.profiles.openclaw.cdpPort = %#v, want 20004", openclawProfile["cdpPort"])
+	}
+}
+
+func TestWriteOpenClawGatewayConfigPreservesExplicitTrustedProxyPassword(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-651")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"gateway":{"auth":{"password":"custom-password"}}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	req := CreateGatewayRequest{InstanceID: 651, UserID: 45, UID: 200651, GID: 200651}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20003); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	auth := objectAt(t, objectAt(t, readOpenClawConfigForTest(t, configPath), "gateway"), "auth")
+	if auth["password"] != "custom-password" {
+		t.Fatalf("gateway.auth.password = %#v, want explicit password preserved", auth["password"])
 	}
 }
 

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -158,6 +159,16 @@ func TestWriteOpenClawGatewayConfigMergesControlUIWithoutOverwritingExistingConf
 	if browser["executablePath"] != openClawBrowserExecutablePath {
 		t.Fatalf("browser.executablePath = %#v, want %s", browser["executablePath"], openClawBrowserExecutablePath)
 	}
+	openclawProfile := objectAt(t, objectAt(t, browser, "profiles"), "openclaw")
+	if openclawProfile["driver"] != "openclaw" {
+		t.Fatalf("browser.profiles.openclaw.driver = %#v, want openclaw", openclawProfile["driver"])
+	}
+	if openclawProfile["cdpPort"] != float64(20004) {
+		t.Fatalf("browser.profiles.openclaw.cdpPort = %#v, want 20004", openclawProfile["cdpPort"])
+	}
+	if openclawProfile["color"] != openClawManagedBrowserColor {
+		t.Fatalf("browser.profiles.openclaw.color = %#v, want %s", openclawProfile["color"], openClawManagedBrowserColor)
+	}
 	providerModels, ok := autoProvider["models"].([]any)
 	if !ok {
 		t.Fatalf("models.providers.auto.models = %#v, want array", autoProvider["models"])
@@ -206,6 +217,10 @@ func TestWriteOpenClawGatewayConfigCompletesPartialBrowserConfig(t *testing.T) {
 	if browser["executablePath"] != openClawBrowserExecutablePath || browser["headless"] != true || browser["noSandbox"] != true {
 		t.Fatalf("completed browser config = %#v", browser)
 	}
+	openclawProfile := objectAt(t, objectAt(t, browser, "profiles"), "openclaw")
+	if openclawProfile["cdpPort"] != float64(20004) {
+		t.Fatalf("browser.profiles.openclaw.cdpPort = %#v, want 20004", openclawProfile["cdpPort"])
+	}
 }
 
 func TestWriteOpenClawGatewayConfigPreservesExplicitBrowserConfig(t *testing.T) {
@@ -227,6 +242,94 @@ func TestWriteOpenClawGatewayConfigPreservesExplicitBrowserConfig(t *testing.T) 
 	browser := objectAt(t, readOpenClawConfigForTest(t, configPath), "browser")
 	if browser["enabled"] != false || browser["executablePath"] != "/opt/custom-browser" || browser["headless"] != false || browser["noSandbox"] != false {
 		t.Fatalf("explicit browser config was overwritten: %#v", browser)
+	}
+}
+
+func TestWriteOpenClawGatewayConfigPinsManagedBrowserCDPInsideAllocatedPortBlock(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-415")
+	configPath := filepath.Join(workspace, "home", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	existing := []byte(`{
+  "browser": {
+    "enabled": false,
+    "executablePath": "/opt/custom-browser",
+    "headless": false,
+    "noSandbox": false,
+    "profiles": {
+      "openclaw": {
+        "driver": "legacy",
+        "cdpPort": 20053,
+        "color": "#00AA00",
+        "viewport": "keep"
+      },
+      "remote-review": {
+        "driver": "remote",
+        "cdpPort": 41000
+      }
+    }
+  }
+}`)
+	if err := os.WriteFile(configPath, existing, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	req := CreateGatewayRequest{InstanceID: 415, UserID: 45, UID: 200415, GID: 200415}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20042); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "20053") {
+		t.Fatalf("config still contains stale default CDP port 20053: %s", string(data))
+	}
+	merged := readOpenClawConfigForTest(t, configPath)
+	gatewayConfig := objectAt(t, merged, "gateway")
+	if gatewayConfig["port"] != float64(20042) {
+		t.Fatalf("gateway.port = %#v, want 20042", gatewayConfig["port"])
+	}
+	browser := objectAt(t, merged, "browser")
+	if browser["enabled"] != false || browser["executablePath"] != "/opt/custom-browser" || browser["headless"] != false || browser["noSandbox"] != false {
+		t.Fatalf("explicit browser config was overwritten: %#v", browser)
+	}
+	profiles := objectAt(t, browser, "profiles")
+	openclawProfile := objectAt(t, profiles, "openclaw")
+	if openclawProfile["driver"] != "openclaw" {
+		t.Fatalf("browser.profiles.openclaw.driver = %#v, want openclaw", openclawProfile["driver"])
+	}
+	if openclawProfile["cdpPort"] != float64(20043) {
+		t.Fatalf("browser.profiles.openclaw.cdpPort = %#v, want 20043", openclawProfile["cdpPort"])
+	}
+	if openclawProfile["color"] != "#00AA00" || openclawProfile["viewport"] != "keep" {
+		t.Fatalf("openclaw profile non-port config was not preserved: %#v", openclawProfile)
+	}
+	remoteProfile := objectAt(t, profiles, "remote-review")
+	if remoteProfile["driver"] != "remote" || remoteProfile["cdpPort"] != float64(41000) {
+		t.Fatalf("remote browser profile was not preserved: %#v", remoteProfile)
+	}
+	if gotBrowserControlPort := int(openclawProfile["cdpPort"].(float64)) + 1; gotBrowserControlPort != 20044 {
+		t.Fatalf("derived Browser Control port = %d, want 20044", gotBrowserControlPort)
+	}
+}
+
+func TestWriteOpenClawGatewayConfigRejectsPortBlockOutsideValidRange(t *testing.T) {
+	for _, port := range []int{0, 65534} {
+		t.Run(strconv.Itoa(port), func(t *testing.T) {
+			workspace := filepath.Join(t.TempDir(), "openclaw", "user-45", "instance-67")
+			req := CreateGatewayRequest{InstanceID: 67, UserID: 45, UID: 200067, GID: 200067}
+
+			err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, port)
+			if err == nil {
+				t.Fatal("WriteGatewayConfig() error = nil, want invalid port error")
+			}
+			if !strings.Contains(err.Error(), "invalid gateway port") {
+				t.Fatalf("WriteGatewayConfig() error = %q, want invalid gateway port", err)
+			}
+		})
 	}
 }
 

--- a/clawmanager-agent/internal/runtime/openclaw/managed_defaults_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/managed_defaults_test.go
@@ -4,10 +4,76 @@ import "testing"
 
 func assertPlatformDefaults(t *testing.T, config map[string]any) {
 	t.Helper()
+	models := objectAt(t, config, "models")
+	if models["mode"] != "merge" {
+		t.Fatalf("models.mode = %#v, want merge", models["mode"])
+	}
+
+	agentDefaults := objectAt(t, objectAt(t, config, "agents"), "defaults")
+	memorySearch := objectAt(t, agentDefaults, "memorySearch")
+	if memorySearch["enabled"] != true || memorySearch["provider"] != "none" {
+		t.Fatalf("agents.defaults.memorySearch = %#v, want managed defaults", memorySearch)
+	}
+	compaction := objectAt(t, agentDefaults, "compaction")
+	if compaction["mode"] != "default" ||
+		compaction["reserveTokens"] != float64(32768) ||
+		compaction["reserveTokensFloor"] != float64(20000) ||
+		compaction["keepRecentTokens"] != float64(30000) ||
+		compaction["maxHistoryShare"] != 0.65 ||
+		compaction["notifyUser"] != true {
+		t.Fatalf("agents.defaults.compaction = %#v, want managed defaults", compaction)
+	}
+	if objectAt(t, compaction, "memoryFlush")["enabled"] != true {
+		t.Fatalf("agents.defaults.compaction.memoryFlush = %#v, want enabled", objectAt(t, compaction, "memoryFlush"))
+	}
+	if agentDefaults["maxConcurrent"] != float64(4) {
+		t.Fatalf("agents.defaults.maxConcurrent = %#v, want 4", agentDefaults["maxConcurrent"])
+	}
+	if objectAt(t, agentDefaults, "subagents")["maxConcurrent"] != float64(8) {
+		t.Fatalf("agents.defaults.subagents.maxConcurrent = %#v, want 8", objectAt(t, agentDefaults, "subagents")["maxConcurrent"])
+	}
+
+	tools := objectAt(t, config, "tools")
+	if tools["profile"] != "full" {
+		t.Fatalf("tools.profile = %#v, want full", tools["profile"])
+	}
+	commands := objectAt(t, config, "commands")
+	if commands["native"] != "auto" ||
+		commands["nativeSkills"] != "auto" ||
+		commands["restart"] != true ||
+		commands["ownerDisplay"] != "raw" {
+		t.Fatalf("commands = %#v, want managed defaults", commands)
+	}
+	groupChat := objectAt(t, objectAt(t, config, "messages"), "groupChat")
+	if groupChat["visibleReplies"] != "automatic" {
+		t.Fatalf("messages.groupChat.visibleReplies = %#v, want automatic", groupChat["visibleReplies"])
+	}
+
 	gateway := objectAt(t, config, "gateway")
 	if gateway["port"] != float64(20003) {
 		t.Fatalf("gateway.port = %#v, want 20003", gateway["port"])
 	}
+	if gateway["mode"] != "local" {
+		t.Fatalf("gateway.mode = %#v, want local", gateway["mode"])
+	}
+	tailscale := objectAt(t, gateway, "tailscale")
+	if tailscale["mode"] != "off" || tailscale["resetOnExit"] != false {
+		t.Fatalf("gateway.tailscale = %#v, want managed defaults", tailscale)
+	}
+	deniedCommands, ok := objectAt(t, gateway, "nodes")["denyCommands"].([]any)
+	if !ok {
+		t.Fatalf("gateway.nodes.denyCommands = %#v, want array", objectAt(t, gateway, "nodes")["denyCommands"])
+	}
+	if got := stringSet(deniedCommands); len(got) != len(openClawDefaultDeniedNodeCommands) {
+		t.Fatalf("gateway.nodes.denyCommands = %#v, want managed deny list", deniedCommands)
+	} else {
+		for _, command := range openClawDefaultDeniedNodeCommands {
+			if !got[command] {
+				t.Fatalf("gateway.nodes.denyCommands missing %q: %#v", command, deniedCommands)
+			}
+		}
+	}
+
 	cron := objectAt(t, config, "cron")
 	if cron["enabled"] != true || cron["maxConcurrentRuns"] != float64(2) || cron["sessionRetention"] != "24h" {
 		t.Fatalf("cron = %#v, want managed defaults", cron)
@@ -33,5 +99,19 @@ func assertPlatformDefaults(t *testing.T, config map[string]any) {
 	maintenance := objectAt(t, session, "maintenance")
 	if reset["idleMinutes"] != float64(10080) || reset["mode"] != "idle" || maintenance["maxEntries"] != float64(2000) || maintenance["pruneAfter"] != "180d" {
 		t.Fatalf("session = %#v, want managed defaults", session)
+	}
+
+	pluginEntries := objectAt(t, objectAt(t, config, "plugins"), "entries")
+	for _, pluginID := range openClawDefaultDisabledPlugins {
+		entry := objectAt(t, pluginEntries, pluginID)
+		if entry["enabled"] != false {
+			t.Fatalf("plugins.entries.%s.enabled = %#v, want false", pluginID, entry["enabled"])
+		}
+	}
+	dreaming := objectAt(t, objectAt(t, objectAt(t, pluginEntries, "memory-core"), "config"), "dreaming")
+	if dreaming["enabled"] != true ||
+		dreaming["frequency"] != "0 3 * * *" ||
+		dreaming["timezone"] != "Asia/Shanghai" {
+		t.Fatalf("plugins.entries.memory-core.config.dreaming = %#v, want managed defaults", dreaming)
 	}
 }

--- a/clawmanager-agent/internal/runtime/openclaw/managed_defaults_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/managed_defaults_test.go
@@ -1,0 +1,37 @@
+package openclaw
+
+import "testing"
+
+func assertPlatformDefaults(t *testing.T, config map[string]any) {
+	t.Helper()
+	gateway := objectAt(t, config, "gateway")
+	if gateway["port"] != float64(20003) {
+		t.Fatalf("gateway.port = %#v, want 20003", gateway["port"])
+	}
+	cron := objectAt(t, config, "cron")
+	if cron["enabled"] != true || cron["maxConcurrentRuns"] != float64(2) || cron["sessionRetention"] != "24h" {
+		t.Fatalf("cron = %#v, want managed defaults", cron)
+	}
+	runLog := objectAt(t, cron, "runLog")
+	if runLog["keepLines"] != float64(2000) || runLog["maxBytes"] != "2mb" {
+		t.Fatalf("cron.runLog = %#v, want managed defaults", runLog)
+	}
+	update := objectAt(t, config, "update")
+	if update["checkOnStart"] != false || objectAt(t, update, "auto")["enabled"] != false {
+		t.Fatalf("update = %#v, want managed defaults", update)
+	}
+	internal := objectAt(t, objectAt(t, config, "hooks"), "internal")
+	if internal["enabled"] != true {
+		t.Fatalf("hooks.internal.enabled = %#v, want true", internal["enabled"])
+	}
+	sessionMemory := objectAt(t, objectAt(t, internal, "entries"), "session-memory")
+	if sessionMemory["enabled"] != true || sessionMemory["messages"] != float64(50) {
+		t.Fatalf("hooks.internal.entries.session-memory = %#v, want managed defaults", sessionMemory)
+	}
+	session := objectAt(t, config, "session")
+	reset := objectAt(t, session, "reset")
+	maintenance := objectAt(t, session, "maintenance")
+	if reset["idleMinutes"] != float64(10080) || reset["mode"] != "idle" || maintenance["maxEntries"] != float64(2000) || maintenance["pruneAfter"] != "180d" {
+		t.Fatalf("session = %#v, want managed defaults", session)
+	}
+}

--- a/clawmanager-agent/internal/runtime/openclaw/plugin_runtime.go
+++ b/clawmanager-agent/internal/runtime/openclaw/plugin_runtime.go
@@ -1,0 +1,254 @@
+package openclaw
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/iamlovingit/clawmanager-agent/internal/gateway"
+)
+
+const openClawDefaultsDirEnv = "CLAWMANAGER_OPENCLAW_DEFAULTS_DIR"
+const defaultOpenClawDefaultsDir = "/defaults/.openclaw"
+const defaultOpenClawGlobalPackageDir = "/usr/local/lib/node_modules/openclaw"
+
+var openClawPluginRuntimeDirs = []string{"npm", "plugins", "extensions"}
+var openClawGlobalPackageDir = defaultOpenClawGlobalPackageDir
+
+type openClawInstancePaths struct {
+	Workspace         string
+	Home              string
+	Persistent        string
+	OpenClawWorkspace string
+}
+
+func resolveOpenClawInstancePaths(req gateway.CreateGatewayRequest, workspacePath string) (openClawInstancePaths, error) {
+	paths := openClawInstancePaths{
+		Workspace:  filepath.Clean(workspacePath),
+		Home:       filepath.Join(workspacePath, "home"),
+		Persistent: filepath.Join(workspacePath, "home", ".openclaw"),
+	}
+	paths.OpenClawWorkspace = filepath.Join(paths.Persistent, "workspace")
+
+	checks := []struct {
+		name string
+		want string
+	}{
+		{name: "CLAWMANAGER_WORKSPACE_PATH", want: paths.Workspace},
+		{name: "HOME", want: paths.Home},
+		{name: "CLAWMANAGER_AGENT_PERSISTENT_DIR", want: paths.Persistent},
+	}
+	for _, check := range checks {
+		value, ok := requestEnvValue(req, check.name)
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		if filepath.Clean(value) != filepath.Clean(check.want) {
+			return openClawInstancePaths{}, fmt.Errorf("%s does not match validated Lite workspace", check.name)
+		}
+	}
+	return paths, nil
+}
+
+func seedOpenClawPluginRuntime(req gateway.CreateGatewayRequest, activeRoot string) error {
+	defaultsRoot := strings.TrimSpace(os.Getenv(openClawDefaultsDirEnv))
+	if defaultsRoot == "" {
+		defaultsRoot = defaultOpenClawDefaultsDir
+	}
+	return seedOpenClawPluginRuntimeFrom(defaultsRoot, req, activeRoot)
+}
+
+func seedOpenClawPluginRuntimeFrom(defaultsRoot string, req gateway.CreateGatewayRequest, activeRoot string) error {
+	defaultsRoot = filepath.Clean(defaultsRoot)
+	info, err := os.Stat(defaultsRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ensureDingTalkOpenClawPeer(activeRoot)
+		}
+		return fmt.Errorf("stat OpenClaw defaults: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("OpenClaw defaults path is not a directory: %s", defaultsRoot)
+	}
+
+	for _, name := range openClawPluginRuntimeDirs {
+		source := filepath.Join(defaultsRoot, name)
+		target := filepath.Join(activeRoot, name)
+		copied, err := copyOpenClawPluginDirIfMissing(source, target)
+		if err != nil {
+			return fmt.Errorf("seed OpenClaw plugin runtime %s: %w", name, err)
+		}
+		if copied {
+			if err := chownTree(target, req.UID, req.GID); err != nil {
+				return fmt.Errorf("chown OpenClaw plugin runtime %s: %w", name, err)
+			}
+		}
+	}
+	if err := ensureDingTalkOpenClawPeer(activeRoot); err != nil {
+		return err
+	}
+
+	registryPath := filepath.Join(activeRoot, "plugins", "installs.json")
+	if err := rewriteOpenClawPluginRegistry(registryPath, defaultsRoot, activeRoot); err != nil {
+		return err
+	}
+	if _, err := os.Stat(registryPath); err == nil {
+		if err := gateway.ChownWorkspace(registryPath, req.UID, req.GID); err != nil {
+			return fmt.Errorf("chown OpenClaw plugin registry: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat OpenClaw plugin registry: %w", err)
+	}
+	return nil
+}
+
+func ensureDingTalkOpenClawPeer(activeRoot string) error {
+	nodeModulesDir := filepath.Join(activeRoot, "npm", "node_modules")
+	connectorDir := filepath.Join(nodeModulesDir, "@dingtalk-real-ai", "dingtalk-connector")
+	info, err := os.Stat(connectorDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat DingTalk connector: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("DingTalk connector path is not a directory: %s", connectorDir)
+	}
+
+	linkPath := filepath.Join(nodeModulesDir, "openclaw")
+	linkInfo, err := os.Lstat(linkPath)
+	if err == nil {
+		if linkInfo.Mode()&os.ModeSymlink == 0 {
+			// A real package also satisfies Node's peer dependency lookup. Preserve
+			// instance-owned content instead of replacing it with the image link.
+			return nil
+		}
+		currentTarget, readErr := os.Readlink(linkPath)
+		if readErr != nil {
+			return fmt.Errorf("read OpenClaw peer symlink: %w", readErr)
+		}
+		if currentTarget == openClawGlobalPackageDir {
+			return nil
+		}
+		if removeErr := os.Remove(linkPath); removeErr != nil {
+			return fmt.Errorf("replace OpenClaw peer symlink: %w", removeErr)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat OpenClaw peer path: %w", err)
+	}
+
+	if err := os.MkdirAll(nodeModulesDir, 0o750); err != nil {
+		return fmt.Errorf("create OpenClaw peer directory: %w", err)
+	}
+	if err := os.Symlink(openClawGlobalPackageDir, linkPath); err != nil {
+		return fmt.Errorf("create OpenClaw peer symlink: %w", err)
+	}
+	return nil
+}
+func copyOpenClawPluginDirIfMissing(source, target string) (bool, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("source is not a directory: %s", source)
+	}
+	if _, err := os.Lstat(target); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return false, err
+	}
+	staging, err := os.MkdirTemp(parent, "."+filepath.Base(target)+".seed-*")
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(staging)
+	if err := copyDir(source, staging); err != nil {
+		return false, err
+	}
+	if err := os.Rename(staging, target); err != nil {
+		if _, targetErr := os.Lstat(target); targetErr == nil {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func rewriteOpenClawPluginRegistry(registryPath, defaultsRoot, activeRoot string) error {
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read OpenClaw plugin registry: %w", err)
+	}
+
+	var registry any
+	if err := json.Unmarshal(data, &registry); err != nil {
+		return fmt.Errorf("parse OpenClaw plugin registry: %w", err)
+	}
+	rewritten, changed := rewriteOpenClawPluginPaths(registry, defaultsRoot, activeRoot)
+	if changed {
+		encoded, err := json.MarshalIndent(rewritten, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal OpenClaw plugin registry: %w", err)
+		}
+		if err := os.WriteFile(registryPath, append(encoded, '\n'), 0o600); err != nil {
+			return fmt.Errorf("write OpenClaw plugin registry: %w", err)
+		}
+	}
+	if err := os.Chmod(registryPath, 0o600); err != nil {
+		return fmt.Errorf("chmod OpenClaw plugin registry: %w", err)
+	}
+	return nil
+}
+
+func rewriteOpenClawPluginPaths(value any, defaultsRoot, activeRoot string) (any, bool) {
+	changed := false
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			rewritten, childChanged := rewriteOpenClawPluginPaths(child, defaultsRoot, activeRoot)
+			typed[key] = rewritten
+			changed = changed || childChanged
+		}
+		return typed, changed
+	case []any:
+		for i, child := range typed {
+			rewritten, childChanged := rewriteOpenClawPluginPaths(child, defaultsRoot, activeRoot)
+			typed[i] = rewritten
+			changed = changed || childChanged
+		}
+		return typed, changed
+	case string:
+		return rewriteOpenClawPathPrefix(typed, defaultsRoot, activeRoot)
+	default:
+		return value, false
+	}
+}
+
+func rewriteOpenClawPathPrefix(value, prefix, replacement string) (string, bool) {
+	cleanValue := path.Clean(filepath.ToSlash(value))
+	cleanPrefix := strings.TrimSuffix(path.Clean(filepath.ToSlash(prefix)), "/")
+	cleanReplacement := strings.TrimSuffix(path.Clean(filepath.ToSlash(replacement)), "/")
+	if cleanValue == cleanPrefix {
+		return cleanReplacement, true
+	}
+	prefixWithSlash := cleanPrefix + "/"
+	if !strings.HasPrefix(cleanValue, prefixWithSlash) {
+		return value, false
+	}
+	return cleanReplacement + "/" + strings.TrimPrefix(cleanValue, prefixWithSlash), true
+}

--- a/clawmanager-agent/internal/runtime/openclaw/plugin_runtime.go
+++ b/clawmanager-agent/internal/runtime/openclaw/plugin_runtime.go
@@ -12,10 +12,13 @@ import (
 )
 
 const openClawDefaultsDirEnv = "CLAWMANAGER_OPENCLAW_DEFAULTS_DIR"
+const openClawNPMRuntimeModeEnv = "CLAWMANAGER_OPENCLAW_NPM_RUNTIME_MODE"
 const defaultOpenClawDefaultsDir = "/defaults/.openclaw"
 const defaultOpenClawGlobalPackageDir = "/usr/local/lib/node_modules/openclaw"
+const openClawNPMRuntimeModeShared = "shared"
+const openClawNPMRuntimeModeCopy = "copy"
 
-var openClawPluginRuntimeDirs = []string{"npm", "plugins", "extensions"}
+var openClawPluginRuntimeDirs = []string{"plugins", "extensions"}
 var openClawGlobalPackageDir = defaultOpenClawGlobalPackageDir
 
 type openClawInstancePaths struct {
@@ -73,6 +76,35 @@ func seedOpenClawPluginRuntimeFrom(defaultsRoot string, req gateway.CreateGatewa
 	if !info.IsDir() {
 		return fmt.Errorf("OpenClaw defaults path is not a directory: %s", defaultsRoot)
 	}
+	if err := ensureOpenClawDefaultsTraversal(defaultsRoot); err != nil {
+		return fmt.Errorf("prepare OpenClaw defaults traversal: %w", err)
+	}
+
+	mode, err := resolveOpenClawNPMRuntimeMode()
+	if err != nil {
+		return err
+	}
+	if mode == openClawNPMRuntimeModeShared {
+		if err := ensureDingTalkOpenClawPeer(defaultsRoot); err != nil {
+			return fmt.Errorf("prepare shared OpenClaw peer: %w", err)
+		}
+	}
+	npmSource := filepath.Join(defaultsRoot, "npm")
+	npmTarget := filepath.Join(activeRoot, "npm")
+	var npmSeeded bool
+	if mode == openClawNPMRuntimeModeCopy {
+		npmSeeded, err = copyOpenClawPluginDirIfMissing(npmSource, npmTarget)
+	} else {
+		npmSeeded, err = seedSharedOpenClawNPMIfMissing(npmSource, npmTarget)
+	}
+	if err != nil {
+		return fmt.Errorf("seed OpenClaw plugin runtime npm (%s): %w", mode, err)
+	}
+	if npmSeeded {
+		if err := chownTree(npmTarget, req.UID, req.GID); err != nil {
+			return fmt.Errorf("chown OpenClaw plugin runtime npm: %w", err)
+		}
+	}
 
 	for _, name := range openClawPluginRuntimeDirs {
 		source := filepath.Join(defaultsRoot, name)
@@ -101,6 +133,208 @@ func seedOpenClawPluginRuntimeFrom(defaultsRoot string, req gateway.CreateGatewa
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("stat OpenClaw plugin registry: %w", err)
+	}
+	return nil
+}
+
+func ensureOpenClawDefaultsTraversal(defaultsRoot string) error {
+	for _, dir := range []string{
+		filepath.Dir(defaultsRoot),
+		defaultsRoot,
+		filepath.Join(defaultsRoot, "npm"),
+	} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if !info.IsDir() {
+			continue
+		}
+		mode := info.Mode().Perm()
+		readableMode := mode | 0o055
+		if readableMode != mode {
+			if err := os.Chmod(dir, readableMode); err != nil {
+				return fmt.Errorf("chmod %s: %w", dir, err)
+			}
+		}
+	}
+	return nil
+}
+
+func resolveOpenClawNPMRuntimeMode() (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(openClawNPMRuntimeModeEnv)))
+	if mode == "" {
+		return openClawNPMRuntimeModeShared, nil
+	}
+	switch mode {
+	case openClawNPMRuntimeModeShared, openClawNPMRuntimeModeCopy:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid %s %q: want %q or %q", openClawNPMRuntimeModeEnv, mode, openClawNPMRuntimeModeShared, openClawNPMRuntimeModeCopy)
+	}
+}
+
+// seedSharedOpenClawNPMIfMissing creates a small, instance-owned npm root and
+// links each image-provided package into it. The writable package parents let
+// an instance replace a default package or install additional packages without
+// copying the image's complete node_modules tree during gateway startup.
+func seedSharedOpenClawNPMIfMissing(source, target string) (bool, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("source is not a directory: %s", source)
+	}
+	if _, err := os.Lstat(target); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return false, err
+	}
+	staging, err := os.MkdirTemp(parent, "."+filepath.Base(target)+".seed-*")
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(staging)
+	if err := populateSharedOpenClawNPM(source, staging); err != nil {
+		return false, err
+	}
+	if err := os.Rename(staging, target); err != nil {
+		if _, targetErr := os.Lstat(target); targetErr == nil {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func populateSharedOpenClawNPM(source, target string) error {
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(source, entry.Name())
+		targetPath := filepath.Join(target, entry.Name())
+		if entry.Name() == "node_modules" {
+			if err := populateSharedNodeModules(sourcePath, targetPath); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := copyOpenClawNPMRootEntry(sourcePath, targetPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func populateSharedNodeModules(source, target string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source is not a directory: %s", source)
+	}
+	if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(source, entry.Name())
+		targetPath := filepath.Join(target, entry.Name())
+		if entry.Name() == ".bin" && entry.IsDir() {
+			if err := copyDir(sourcePath, targetPath); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), "@") && entry.IsDir() {
+			if err := linkOpenClawPackageScope(sourcePath, targetPath); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := linkOpenClawPackageEntry(sourcePath, targetPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func linkOpenClawPackageScope(source, target string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := linkOpenClawPackageEntry(filepath.Join(source, entry.Name()), filepath.Join(target, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyOpenClawNPMRootEntry(source, target string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkTarget, err := os.Readlink(source)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(linkTarget, target)
+	}
+	if info.IsDir() {
+		return copyDir(source, target)
+	}
+	if info.Mode().IsRegular() {
+		return copyRegularFile(source, target, info.Mode().Perm())
+	}
+	return nil
+}
+
+func linkOpenClawPackageEntry(source, target string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkTarget, err := os.Readlink(source)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(linkTarget, target)
+	}
+	if info.IsDir() {
+		return os.Symlink(filepath.Clean(source), target)
+	}
+	if info.Mode().IsRegular() {
+		return copyRegularFile(source, target, info.Mode().Perm())
 	}
 	return nil
 }
@@ -145,6 +379,12 @@ func ensureDingTalkOpenClawPeer(activeRoot string) error {
 		return fmt.Errorf("create OpenClaw peer directory: %w", err)
 	}
 	if err := os.Symlink(openClawGlobalPackageDir, linkPath); err != nil {
+		if os.IsExist(err) {
+			currentTarget, readErr := os.Readlink(linkPath)
+			if readErr == nil && currentTarget == openClawGlobalPackageDir {
+				return nil
+			}
+		}
 		return fmt.Errorf("create OpenClaw peer symlink: %w", err)
 	}
 	return nil

--- a/clawmanager-agent/internal/runtime/openclaw/plugin_runtime_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/plugin_runtime_test.go
@@ -1,0 +1,200 @@
+package openclaw
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWriteOpenClawGatewayConfigSeedsInstancePluginRuntime(t *testing.T) {
+	root := t.TempDir()
+	defaultsRoot := filepath.Join(root, "defaults", ".openclaw")
+	feishuSource := filepath.Join(defaultsRoot, "npm", "node_modules", "@openclaw", "feishu")
+	if err := os.MkdirAll(feishuSource, 0o755); err != nil {
+		t.Fatalf("mkdir default npm plugin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(feishuSource, "index.js"), []byte("image-plugin"), 0o644); err != nil {
+		t.Fatalf("write default npm plugin: %v", err)
+	}
+	extensionSource := filepath.Join(defaultsRoot, "extensions", "sample-channel")
+	if err := os.MkdirAll(extensionSource, 0o755); err != nil {
+		t.Fatalf("mkdir default extension: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(extensionSource, "openclaw.plugin.json"), []byte(`{"id":"sample-channel"}`), 0o644); err != nil {
+		t.Fatalf("write default extension: %v", err)
+	}
+	pluginsSource := filepath.Join(defaultsRoot, "plugins")
+	if err := os.MkdirAll(pluginsSource, 0o755); err != nil {
+		t.Fatalf("mkdir default plugin registry: %v", err)
+	}
+	registry := map[string]any{
+		"installRecords": map[string]any{
+			"feishu": map[string]any{
+				"installPath": filepath.ToSlash(feishuSource),
+			},
+		},
+		"plugins": []any{
+			map[string]any{
+				"pluginId":     "feishu",
+				"manifestPath": filepath.ToSlash(filepath.Join(feishuSource, "openclaw.plugin.json")),
+			},
+		},
+	}
+	registryData, err := json.Marshal(registry)
+	if err != nil {
+		t.Fatalf("marshal default plugin registry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginsSource, "installs.json"), registryData, 0o644); err != nil {
+		t.Fatalf("write default plugin registry: %v", err)
+	}
+
+	linkTarget := "/usr/local/lib/node_modules/openclaw"
+	if runtime.GOOS != "windows" {
+		if err := os.Symlink(linkTarget, filepath.Join(defaultsRoot, "npm", "node_modules", "openclaw")); err != nil {
+			t.Fatalf("create default npm peer symlink: %v", err)
+		}
+	}
+
+	t.Setenv(openClawDefaultsDirEnv, defaultsRoot)
+	workspace := filepath.Join(root, "workspaces", "openclaw", "user-1", "instance-256")
+	home := filepath.Join(workspace, "home")
+	activeRoot := filepath.Join(home, ".openclaw")
+	req := CreateGatewayRequest{
+		AgentType: "openclaw", UserID: 1, InstanceID: 256,
+		Environment: map[string]string{
+			"CLAWMANAGER_WORKSPACE_PATH":       workspace,
+			"HOME":                             home,
+			"CLAWMANAGER_AGENT_PERSISTENT_DIR": activeRoot,
+		},
+	}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20056); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	feishuTarget := filepath.Join(activeRoot, "npm", "node_modules", "@openclaw", "feishu", "index.js")
+	if got, err := os.ReadFile(feishuTarget); err != nil {
+		t.Fatalf("read copied npm plugin: %v", err)
+	} else if string(got) != "image-plugin" {
+		t.Fatalf("copied npm plugin = %q, want image content", got)
+	}
+	if _, err := os.Stat(filepath.Join(activeRoot, "extensions", "sample-channel", "openclaw.plugin.json")); err != nil {
+		t.Fatalf("stat copied extension: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if got, err := os.Readlink(filepath.Join(activeRoot, "npm", "node_modules", "openclaw")); err != nil {
+			t.Fatalf("read copied npm peer symlink: %v", err)
+		} else if got != linkTarget {
+			t.Fatalf("copied npm peer symlink = %q, want %q", got, linkTarget)
+		}
+	}
+
+	copiedRegistry, err := os.ReadFile(filepath.Join(activeRoot, "plugins", "installs.json"))
+	if err != nil {
+		t.Fatalf("read copied plugin registry: %v", err)
+	}
+	if strings.Contains(string(copiedRegistry), filepath.ToSlash(defaultsRoot)+"/") {
+		t.Fatal("copied plugin registry still references defaults root")
+	}
+	if !strings.Contains(string(copiedRegistry), filepath.ToSlash(activeRoot)+"/") {
+		t.Fatal("copied plugin registry does not reference instance plugin root")
+	}
+
+	configData, err := os.ReadFile(filepath.Join(activeRoot, "openclaw.json"))
+	if err != nil {
+		t.Fatalf("read instance config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(configData, &config); err != nil {
+		t.Fatalf("parse instance config: %v", err)
+	}
+	if got, want := objectAt(t, objectAt(t, config, "agents"), "defaults")["workspace"], filepath.ToSlash(filepath.Join(activeRoot, "workspace")); got != want {
+		t.Fatalf("agents.defaults.workspace = %#v, want %q", got, want)
+	}
+
+	if err := os.WriteFile(feishuTarget, []byte("user-modified"), 0o644); err != nil {
+		t.Fatalf("modify instance plugin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(feishuSource, "index.js"), []byte("new-image-plugin"), 0o644); err != nil {
+		t.Fatalf("modify default plugin fixture: %v", err)
+	}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20056); err != nil {
+		t.Fatalf("second WriteGatewayConfig() error = %v", err)
+	}
+	if got, err := os.ReadFile(feishuTarget); err != nil {
+		t.Fatalf("read user-modified instance plugin: %v", err)
+	} else if string(got) != "user-modified" {
+		t.Fatalf("instance plugin was overwritten: %q", got)
+	}
+}
+
+func TestWriteOpenClawGatewayConfigRejectsMismatchedInjectedPersistentDir(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspaces", "openclaw", "user-1", "instance-256")
+	req := CreateGatewayRequest{
+		AgentType: "openclaw", UserID: 1, InstanceID: 256,
+		Environment: map[string]string{
+			"CLAWMANAGER_WORKSPACE_PATH":       workspace,
+			"HOME":                             filepath.Join(workspace, "home"),
+			"CLAWMANAGER_AGENT_PERSISTENT_DIR": filepath.Join(root, "other-instance", ".openclaw"),
+		},
+	}
+	err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20056)
+	if err == nil || !strings.Contains(err.Error(), "CLAWMANAGER_AGENT_PERSISTENT_DIR") {
+		t.Fatalf("WriteGatewayConfig() error = %v, want mismatched persistent dir error", err)
+	}
+}
+
+func TestWriteOpenClawGatewayConfigRepairsMissingDingTalkOpenClawPeer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated Windows privileges")
+	}
+
+	root := t.TempDir()
+	globalPackage := filepath.Join(root, "global", "openclaw")
+	if err := os.MkdirAll(globalPackage, 0o755); err != nil {
+		t.Fatalf("mkdir global OpenClaw package: %v", err)
+	}
+	previousGlobalPackage := openClawGlobalPackageDir
+	openClawGlobalPackageDir = globalPackage
+	t.Cleanup(func() { openClawGlobalPackageDir = previousGlobalPackage })
+
+	defaultsRoot := filepath.Join(root, "defaults", ".openclaw")
+	connectorSource := filepath.Join(defaultsRoot, "npm", "node_modules", "@dingtalk-real-ai", "dingtalk-connector")
+	if err := os.MkdirAll(connectorSource, 0o755); err != nil {
+		t.Fatalf("mkdir default DingTalk connector: %v", err)
+	}
+	t.Setenv(openClawDefaultsDirEnv, defaultsRoot)
+
+	workspace := filepath.Join(root, "workspaces", "openclaw", "user-1", "instance-350")
+	activeRoot := filepath.Join(workspace, "home", ".openclaw")
+	// Simulate a previously seeded instance whose npm directory exists but
+	// whose OpenClaw peer link was omitted.
+	connectorTarget := filepath.Join(activeRoot, "npm", "node_modules", "@dingtalk-real-ai", "dingtalk-connector")
+	if err := os.MkdirAll(connectorTarget, 0o755); err != nil {
+		t.Fatalf("mkdir instance DingTalk connector: %v", err)
+	}
+
+	req := CreateGatewayRequest{AgentType: "openclaw", UserID: 1, InstanceID: 350}
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20009); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	linkPath := filepath.Join(activeRoot, "npm", "node_modules", "openclaw")
+	if got, err := os.Readlink(linkPath); err != nil {
+		t.Fatalf("read repaired OpenClaw peer symlink: %v", err)
+	} else if got != globalPackage {
+		t.Fatalf("OpenClaw peer symlink = %q, want %q", got, globalPackage)
+	}
+
+	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20009); err != nil {
+		t.Fatalf("second WriteGatewayConfig() error = %v", err)
+	}
+	if got, err := os.Readlink(linkPath); err != nil {
+		t.Fatalf("read idempotent OpenClaw peer symlink: %v", err)
+	} else if got != globalPackage {
+		t.Fatalf("idempotent OpenClaw peer symlink = %q, want %q", got, globalPackage)
+	}
+}

--- a/clawmanager-agent/internal/runtime/openclaw/plugin_runtime_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/plugin_runtime_test.go
@@ -6,10 +6,16 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
 func TestWriteOpenClawGatewayConfigSeedsInstancePluginRuntime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows test runners commonly cannot create symlinks without an
+		// elevated token. The copy mode remains the supported rollback path.
+		t.Setenv(openClawNPMRuntimeModeEnv, openClawNPMRuntimeModeCopy)
+	}
 	root := t.TempDir()
 	defaultsRoot := filepath.Join(root, "defaults", ".openclaw")
 	feishuSource := filepath.Join(defaultsRoot, "npm", "node_modules", "@openclaw", "feishu")
@@ -74,11 +80,21 @@ func TestWriteOpenClawGatewayConfigSeedsInstancePluginRuntime(t *testing.T) {
 		t.Fatalf("WriteGatewayConfig() error = %v", err)
 	}
 
-	feishuTarget := filepath.Join(activeRoot, "npm", "node_modules", "@openclaw", "feishu", "index.js")
+	feishuPackageTarget := filepath.Join(activeRoot, "npm", "node_modules", "@openclaw", "feishu")
+	feishuTarget := filepath.Join(feishuPackageTarget, "index.js")
 	if got, err := os.ReadFile(feishuTarget); err != nil {
-		t.Fatalf("read copied npm plugin: %v", err)
+		t.Fatalf("read seeded npm plugin: %v", err)
 	} else if string(got) != "image-plugin" {
-		t.Fatalf("copied npm plugin = %q, want image content", got)
+		t.Fatalf("seeded npm plugin = %q, want image content", got)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Lstat(feishuPackageTarget)
+		if err != nil {
+			t.Fatalf("stat shared npm plugin: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("shared npm plugin mode = %v, want symlink", info.Mode())
+		}
 	}
 	if _, err := os.Stat(filepath.Join(activeRoot, "extensions", "sample-channel", "openclaw.plugin.json")); err != nil {
 		t.Fatalf("stat copied extension: %v", err)
@@ -114,6 +130,14 @@ func TestWriteOpenClawGatewayConfigSeedsInstancePluginRuntime(t *testing.T) {
 		t.Fatalf("agents.defaults.workspace = %#v, want %q", got, want)
 	}
 
+	if runtime.GOOS != "windows" {
+		if err := os.Remove(feishuPackageTarget); err != nil {
+			t.Fatalf("remove shared npm plugin link: %v", err)
+		}
+		if err := os.MkdirAll(feishuPackageTarget, 0o755); err != nil {
+			t.Fatalf("create instance npm plugin override: %v", err)
+		}
+	}
 	if err := os.WriteFile(feishuTarget, []byte("user-modified"), 0o644); err != nil {
 		t.Fatalf("modify instance plugin: %v", err)
 	}
@@ -127,6 +151,85 @@ func TestWriteOpenClawGatewayConfigSeedsInstancePluginRuntime(t *testing.T) {
 		t.Fatalf("read user-modified instance plugin: %v", err)
 	} else if string(got) != "user-modified" {
 		t.Fatalf("instance plugin was overwritten: %q", got)
+	}
+}
+
+func TestSeedOpenClawPluginRuntimeCopyModeKeepsIndependentNPMFiles(t *testing.T) {
+	t.Setenv(openClawNPMRuntimeModeEnv, openClawNPMRuntimeModeCopy)
+	root := t.TempDir()
+	defaultsRoot := filepath.Join(root, "defaults", ".openclaw")
+	sourceFile := filepath.Join(defaultsRoot, "npm", "node_modules", "sample-plugin", "index.js")
+	if err := os.MkdirAll(filepath.Dir(sourceFile), 0o755); err != nil {
+		t.Fatalf("mkdir default npm plugin: %v", err)
+	}
+	if err := os.WriteFile(sourceFile, []byte("image-plugin"), 0o644); err != nil {
+		t.Fatalf("write default npm plugin: %v", err)
+	}
+
+	activeRoot := filepath.Join(root, "active", ".openclaw")
+	if err := seedOpenClawPluginRuntimeFrom(defaultsRoot, CreateGatewayRequest{}, activeRoot); err != nil {
+		t.Fatalf("seedOpenClawPluginRuntimeFrom() error = %v", err)
+	}
+	targetFile := filepath.Join(activeRoot, "npm", "node_modules", "sample-plugin", "index.js")
+	if info, err := os.Lstat(filepath.Dir(targetFile)); err != nil {
+		t.Fatalf("stat copied npm plugin: %v", err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("copy-mode npm plugin mode = %v, want real directory", info.Mode())
+	}
+	if err := os.WriteFile(targetFile, []byte("instance-plugin"), 0o644); err != nil {
+		t.Fatalf("modify copied npm plugin: %v", err)
+	}
+	if got, err := os.ReadFile(sourceFile); err != nil {
+		t.Fatalf("read default npm plugin: %v", err)
+	} else if string(got) != "image-plugin" {
+		t.Fatalf("default npm plugin changed through copy-mode target: %q", got)
+	}
+}
+
+func TestSeedOpenClawPluginRuntimeRejectsUnknownNPMMode(t *testing.T) {
+	t.Setenv(openClawNPMRuntimeModeEnv, "unexpected")
+	defaultsRoot := filepath.Join(t.TempDir(), "defaults", ".openclaw")
+	if err := os.MkdirAll(defaultsRoot, 0o755); err != nil {
+		t.Fatalf("mkdir defaults root: %v", err)
+	}
+
+	err := seedOpenClawPluginRuntimeFrom(defaultsRoot, CreateGatewayRequest{}, filepath.Join(t.TempDir(), ".openclaw"))
+	if err == nil || !strings.Contains(err.Error(), openClawNPMRuntimeModeEnv) {
+		t.Fatalf("seedOpenClawPluginRuntimeFrom() error = %v, want invalid mode diagnostic", err)
+	}
+}
+
+func TestSeedOpenClawPluginRuntimeRepairsDefaultsTraversal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix directory traversal mode bits")
+	}
+
+	root := t.TempDir()
+	defaultsParent := filepath.Join(root, "defaults")
+	defaultsRoot := filepath.Join(defaultsParent, ".openclaw")
+	npmRoot := filepath.Join(defaultsRoot, "npm")
+	if err := os.MkdirAll(npmRoot, 0o700); err != nil {
+		t.Fatalf("mkdir defaults npm root: %v", err)
+	}
+	for _, dir := range []string{defaultsParent, defaultsRoot, npmRoot} {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			t.Fatalf("chmod %s: %v", dir, err)
+		}
+	}
+
+	t.Setenv(openClawNPMRuntimeModeEnv, openClawNPMRuntimeModeCopy)
+	if err := seedOpenClawPluginRuntimeFrom(defaultsRoot, CreateGatewayRequest{}, filepath.Join(root, "active")); err != nil {
+		t.Fatalf("seedOpenClawPluginRuntimeFrom() error = %v", err)
+	}
+
+	for _, dir := range []string{defaultsParent, defaultsRoot, npmRoot} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s: %v", dir, err)
+		}
+		if got := info.Mode().Perm(); got&0o055 != 0o055 {
+			t.Errorf("mode %s = %o, want group/other read and traversal bits", dir, got)
+		}
 	}
 }
 
@@ -188,6 +291,12 @@ func TestWriteOpenClawGatewayConfigRepairsMissingDingTalkOpenClawPeer(t *testing
 	} else if got != globalPackage {
 		t.Fatalf("OpenClaw peer symlink = %q, want %q", got, globalPackage)
 	}
+	sharedLinkPath := filepath.Join(defaultsRoot, "npm", "node_modules", "openclaw")
+	if got, err := os.Readlink(sharedLinkPath); err != nil {
+		t.Fatalf("read shared OpenClaw peer symlink: %v", err)
+	} else if got != globalPackage {
+		t.Fatalf("shared OpenClaw peer symlink = %q, want %q", got, globalPackage)
+	}
 
 	if err := WriteGatewayConfig(Config{GatewayAuthMode: "trusted-proxy"}, req, workspace, 20009); err != nil {
 		t.Fatalf("second WriteGatewayConfig() error = %v", err)
@@ -196,5 +305,51 @@ func TestWriteOpenClawGatewayConfigRepairsMissingDingTalkOpenClawPeer(t *testing
 		t.Fatalf("read idempotent OpenClaw peer symlink: %v", err)
 	} else if got != globalPackage {
 		t.Fatalf("idempotent OpenClaw peer symlink = %q, want %q", got, globalPackage)
+	}
+}
+
+func TestEnsureDingTalkOpenClawPeerConcurrent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated Windows privileges")
+	}
+
+	root := t.TempDir()
+	globalPackage := filepath.Join(root, "global", "openclaw")
+	if err := os.MkdirAll(globalPackage, 0o755); err != nil {
+		t.Fatalf("mkdir global OpenClaw package: %v", err)
+	}
+	previousGlobalPackage := openClawGlobalPackageDir
+	openClawGlobalPackageDir = globalPackage
+	defer func() { openClawGlobalPackageDir = previousGlobalPackage }()
+
+	activeRoot := filepath.Join(root, ".openclaw")
+	connectorDir := filepath.Join(activeRoot, "npm", "node_modules", "@dingtalk-real-ai", "dingtalk-connector")
+	if err := os.MkdirAll(connectorDir, 0o755); err != nil {
+		t.Fatalf("mkdir DingTalk connector: %v", err)
+	}
+
+	const workers = 32
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- ensureDingTalkOpenClawPeer(activeRoot)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("ensureDingTalkOpenClawPeer() error = %v", err)
+		}
+	}
+
+	linkPath := filepath.Join(activeRoot, "npm", "node_modules", "openclaw")
+	if got, err := os.Readlink(linkPath); err != nil {
+		t.Fatalf("read concurrent OpenClaw peer symlink: %v", err)
+	} else if got != globalPackage {
+		t.Fatalf("concurrent OpenClaw peer symlink = %q, want %q", got, globalPackage)
 	}
 }

--- a/clawmanager-agent/internal/runtime/openclaw/profile.go
+++ b/clawmanager-agent/internal/runtime/openclaw/profile.go
@@ -61,8 +61,8 @@ func (p Profile) PrepareWorkspace(cfg gateway.Config, req gateway.CreateGatewayR
 	return nil
 }
 
-func (p Profile) WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string) error {
-	return WriteGatewayConfig(cfg, req, workspacePath)
+func (p Profile) WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, workspacePath string, port int) error {
+	return WriteGatewayConfig(cfg, req, workspacePath, port)
 }
 
 func (p Profile) HealthChecker(cfg gateway.Config) gateway.GatewayHealthChecker {

--- a/clawmanager-agent/internal/runtime/profile.go
+++ b/clawmanager-agent/internal/runtime/profile.go
@@ -42,7 +42,7 @@ func (p StaticProfile) PrepareWorkspace(_ gateway.Config, _ gateway.CreateGatewa
 	return nil
 }
 
-func (p StaticProfile) WriteGatewayConfig(gateway.Config, gateway.CreateGatewayRequest, string) error {
+func (p StaticProfile) WriteGatewayConfig(gateway.Config, gateway.CreateGatewayRequest, string, int) error {
 	return nil
 }
 

--- a/clawmanager-agent/scripts/clawmanager-agent-run
+++ b/clawmanager-agent/scripts/clawmanager-agent-run
@@ -6,6 +6,11 @@ if [ -z "${RUNTIME_AGENT_CONTROL_TOKEN:-}" ] && [ -z "${RUNTIME_AGENT_REPORT_TOK
   sleep infinity
 fi
 
+if [ -d /defaults/.openclaw/npm ]; then
+  chmod 0755 /defaults /defaults/.openclaw
+  chmod -R a+rX /defaults/.openclaw/npm
+fi
+
 AGENT_DATA_DIR="${RUNTIME_AGENT_DATA_DIR:-/var/lib/clawmanager-agent}"
 mkdir -p "$AGENT_DATA_DIR"
 

--- a/hermes/rootfs/usr/local/bin/start-hermes-dashboard-gateway
+++ b/hermes/rootfs/usr/local/bin/start-hermes-dashboard-gateway
@@ -17,6 +17,8 @@ mkdir -p \
     "${XDG_CONFIG_HOME}" \
     "${XDG_DATA_HOME}"
 
+/usr/local/bin/hermes-apply-runtime-config
+
 env_file="${HERMES_HOME}/.env"
 if [ -f "${env_file}" ]; then
     while IFS= read -r line || [ -n "${line:-}" ]; do

--- a/hermes/rootfs_scripts_test.go
+++ b/hermes/rootfs_scripts_test.go
@@ -87,3 +87,22 @@ func TestDockerfilePinsHermesAgentVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestDashboardGatewayScriptAppliesRuntimeConfigBeforeReadingEnvFile(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("rootfs", "usr", "local", "bin", "start-hermes-dashboard-gateway"))
+	if err != nil {
+		t.Fatalf("read start-hermes-dashboard-gateway: %v", err)
+	}
+	script := string(data)
+	applyIndex := strings.Index(script, "/usr/local/bin/hermes-apply-runtime-config")
+	envFileIndex := strings.Index(script, `env_file="${HERMES_HOME}/.env"`)
+	if applyIndex < 0 {
+		t.Fatal("start-hermes-dashboard-gateway missing hermes-apply-runtime-config")
+	}
+	if envFileIndex < 0 {
+		t.Fatal("start-hermes-dashboard-gateway missing HERMES_HOME env file assignment")
+	}
+	if applyIndex >= envFileIndex {
+		t.Fatal("hermes-apply-runtime-config must run before reading HERMES_HOME/.env")
+	}
+}

--- a/openclaw/Dockerfile.openclaw
+++ b/openclaw/Dockerfile.openclaw
@@ -89,6 +89,14 @@ RUN sed -i 's/\r$//' /etc/services.d/openclaw-agent/run \
   && HOME=/defaults openclaw plugins install @openclaw/feishu@2026.5.4 \
   && rm -rf /tmp/openclaw-redis-team /tmp/openclaw-plugin-pack \
   && chown -R abc:abc /defaults/.openclaw \
+  && chmod 0755 /defaults /defaults/.openclaw \
+  && chmod -R a+rX /defaults/.openclaw/npm \
+  && ln -s /usr/local/lib/node_modules/openclaw /defaults/.openclaw/npm/node_modules/openclaw \
+  && chown -R root:root \
+    /defaults/.openclaw/npm/node_modules/@dingtalk-real-ai/dingtalk-connector \
+    /defaults/.openclaw/npm/node_modules/@openclaw/feishu \
+    /defaults/.openclaw/npm/node_modules/@wecom/wecom-openclaw-plugin \
+  && chown -h root:root /defaults/.openclaw/npm/node_modules/openclaw \
   && chown -R abc:abc /defaults/.config \
   && mkdir -p /var/lib/openclaw-agent /var/lib/clawmanager-agent /var/log/openclaw-agent /etc/openclaw-agent
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,5 +1,8 @@
 # ClawManager OpenClaw Image
 
+> Maintainers adapting channel plugins for the multi-instance Lite runtime
+> should also read the [OpenClaw Lite Channel Adapter Guide](../clawmanager-agent/docs/openclaw-lite-channel-adaptation.md).
+
 <p align="center">
   <img src="docs//assets/openclaw_logo.jpg" alt="ClawManager" width="100%" />
 </p>

--- a/openclaw/README.zh-CN.md
+++ b/openclaw/README.zh-CN.md
@@ -1,5 +1,8 @@
 # ClawManager OpenClaw Image
 
+> 为多实例 Lite runtime 新增或升级 channel 插件前，请同时阅读
+> [OpenClaw Lite Channel 适配指南](../clawmanager-agent/docs/openclaw-lite-channel-adaptation.md)。
+
 <p align="center">
   <img src="docs//assets/openclaw_logo.jpg" alt="ClawManager" width="100%" />
 </p>

--- a/openclaw/defaults-template/.openclaw/openclaw.json
+++ b/openclaw/defaults-template/.openclaw/openclaw.json
@@ -58,12 +58,20 @@
           "auto/model-id": {}
         },
         "workspace": "/config/.openclaw/workspace",
+        "memorySearch": {
+          "enabled": true,
+          "provider": "none"
+        },
         "compaction": {
           "mode": "default",
-          "reserveTokens": 8192,
-          "keepRecentTokens": 50000,
-          "maxHistoryShare": 0.85,
-          "notifyUser": true
+          "reserveTokens": 32768,
+          "reserveTokensFloor": 20000,
+          "keepRecentTokens": 30000,
+          "maxHistoryShare": 0.65,
+          "notifyUser": true,
+          "memoryFlush": {
+            "enabled": true
+          }
         },
         "maxConcurrent": 4,
         "subagents": {
@@ -76,8 +84,8 @@
         "enabled": true,
         "entries": {
           "session-memory": {
-              "enabled": true,
-              "messages": 50
+            "enabled": true,
+            "messages": 50
           }
         }
       }
@@ -169,6 +177,15 @@
         },
         "redis-team": {
           "enabled": false
+        },
+        "memory-core": {
+          "config": {
+            "dreaming": {
+              "enabled": true,
+              "frequency": "0 3 * * *",
+              "timezone": "Asia/Shanghai"
+            }
+          }
         }
       }
     },

--- a/openclaw/dockerfile_permissions_test.go
+++ b/openclaw/dockerfile_permissions_test.go
@@ -1,0 +1,47 @@
+package openclaw_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestImageKeepsBundledPluginsReadableAndRootOwned(t *testing.T) {
+	content, err := os.ReadFile("Dockerfile.openclaw")
+	if err != nil {
+		t.Fatalf("read Dockerfile.openclaw: %v", err)
+	}
+	dockerfile := string(content)
+
+	required := []string{
+		"chmod 0755 /defaults /defaults/.openclaw",
+		"chmod -R a+rX /defaults/.openclaw/npm",
+		"ln -s /usr/local/lib/node_modules/openclaw /defaults/.openclaw/npm/node_modules/openclaw",
+		"chown -h root:root /defaults/.openclaw/npm/node_modules/openclaw",
+		"/defaults/.openclaw/npm/node_modules/@dingtalk-real-ai/dingtalk-connector",
+		"/defaults/.openclaw/npm/node_modules/@openclaw/feishu",
+		"/defaults/.openclaw/npm/node_modules/@wecom/wecom-openclaw-plugin",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(dockerfile, fragment) {
+			t.Errorf("Dockerfile.openclaw is missing %q", fragment)
+		}
+	}
+
+	abcOwnership := strings.Index(dockerfile, "chown -R abc:abc /defaults/.openclaw")
+	rootOwnership := strings.Index(dockerfile, "chown -R root:root")
+	if abcOwnership < 0 || rootOwnership < 0 || rootOwnership < abcOwnership {
+		t.Error("bundled plugin root ownership must be applied after the default abc ownership")
+	}
+
+	runScript, err := os.ReadFile("../clawmanager-agent/scripts/clawmanager-agent-run")
+	if err != nil {
+		t.Fatalf("read clawmanager-agent-run: %v", err)
+	}
+	script := string(runScript)
+	for _, fragment := range required[:2] {
+		if !strings.Contains(script, fragment) {
+			t.Errorf("clawmanager-agent-run is missing %q", fragment)
+		}
+	}
+}


### PR DESCRIPTION
- Apply Lite channel config, initialize plugins, and merge managed OpenClaw defaults
- Support control-plane gateway_port assignment and reserve exact port blocks
- Write assigned gateway ports into OpenClaw config
- Configure default models, agents, tools, commands, cron, session, and gateway settings
- Disable selected plugins by default and enable memory-core dreaming config
- Preserve explicit existing values instead of overwriting user choices
- Normalize port conflict errors and expand test coverage for allocation and defaults