### PR TITLE
Hermes新版适配，定时任务适配

### DIFF
--- a/clawmanager-agent/internal/runtime/hermes/config_writer.go
+++ b/clawmanager-agent/internal/runtime/hermes/config_writer.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/iamlovingit/clawmanager-agent/internal/gateway"
+	"github.com/iamlovingit/clawmanager-agent/internal/scheduledtasks"
 )
 
 const managedConfigStart = "# clawmanager-managed-start"
@@ -40,6 +42,22 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 	}
 	if err := writeHermesGatewayConfig(filepath.Join(hermesHome, "gateway.json"), resolved, req); err != nil {
 		return err
+	}
+	result := scheduledtasks.ApplyHermesFromEnv(hermesHome, func(key string) string {
+		if req.Environment != nil {
+			if value, ok := req.Environment[key]; ok {
+				return value
+			}
+		}
+		if req.Env != nil {
+			if value, ok := req.Env[key]; ok {
+				return value
+			}
+		}
+		return os.Getenv(key)
+	}, req.UID, req.GID)
+	if result.Error != "" {
+		log.Printf("apply hermes scheduled tasks failed (continuing): source_env=%s error=%s", result.SourceEnv, result.Error)
 	}
 	if err := chownHermesHome(hermesHome, req.UID, req.GID); err != nil {
 		return fmt.Errorf("chown hermes home: %w", err)

--- a/clawmanager-agent/internal/runtime/hermes/profile.go
+++ b/clawmanager-agent/internal/runtime/hermes/profile.go
@@ -57,6 +57,7 @@ func (p Profile) GatewayEnv(base []string, cfg gateway.Config, req gateway.Creat
 	env = setEnv(env, "HOST", "0.0.0.0")
 	env = setEnv(env, "PORT", strconv.Itoa(port))
 	env = setEnv(env, "HERMES_ACCEPT_HOOKS", "1")
+	env = applyDashboardBasicAuthEnv(env, cfg, req)
 	env = unsetEnv(
 		env,
 		"RUNTIME_AGENT_CONTROL_TOKEN",
@@ -70,6 +71,51 @@ func (p Profile) GatewayEnv(base []string, cfg gateway.Config, req gateway.Creat
 	} else if cfg.GatewayToken != "" {
 		env = setEnv(env, "RUNTIME_GATEWAY_TOKEN", cfg.GatewayToken)
 	}
+	return env
+}
+
+// applyDashboardBasicAuthEnv ensures Hermes can bind HOST=0.0.0.0 without the
+// deprecated --insecure flag. Password priority:
+//  1. existing HERMES_DASHBOARD_BASIC_AUTH_PASSWORD / PASSWORD_HASH from request env
+//  2. cfg.GatewayToken
+//  3. create-request access token aliases (CLAWMANAGER_DASHBOARD_BASIC_AUTH_PASSWORD,
+//     CLAWMANAGER_INSTANCE_ACCESS_TOKEN, CLAWMANAGER_INSTANCE_TOKEN, CLAWMANAGER_LLM_API_KEY,
+//     OPENAI_API_KEY, CLAWMANAGER_GATEWAY_TOKEN)
+// Username defaults to "clawmanager" unless already set.
+func applyDashboardBasicAuthEnv(env []string, cfg gateway.Config, req gateway.CreateGatewayRequest) []string {
+	username, hasUsername := requestEnvValue(req, "HERMES_DASHBOARD_BASIC_AUTH_USERNAME")
+	password, hasPassword := requestEnvValue(req, "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD")
+	_, hasPasswordHash := requestEnvValue(req, "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH")
+	if hasPassword || hasPasswordHash {
+		if !hasUsername || strings.TrimSpace(username) == "" {
+			env = setEnv(env, "HERMES_DASHBOARD_BASIC_AUTH_USERNAME", "clawmanager")
+		}
+		return env
+	}
+
+	password = strings.TrimSpace(cfg.GatewayToken)
+	if password == "" {
+		if value, ok := requestEnvValue(
+			req,
+			"CLAWMANAGER_DASHBOARD_BASIC_AUTH_PASSWORD",
+			"CLAWMANAGER_INSTANCE_ACCESS_TOKEN",
+			"CLAWMANAGER_INSTANCE_TOKEN",
+			"CLAWMANAGER_LLM_API_KEY",
+			"OPENAI_API_KEY",
+			"CLAWMANAGER_GATEWAY_TOKEN",
+		); ok {
+			password = strings.TrimSpace(value)
+		}
+	}
+	if password == "" {
+		return env
+	}
+
+	if !hasUsername || strings.TrimSpace(username) == "" {
+		username = "clawmanager"
+	}
+	env = setEnv(env, "HERMES_DASHBOARD_BASIC_AUTH_USERNAME", username)
+	env = setEnv(env, "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD", password)
 	return env
 }
 

--- a/clawmanager-agent/internal/runtime/hermes/profile_test.go
+++ b/clawmanager-agent/internal/runtime/hermes/profile_test.go
@@ -89,6 +89,75 @@ func TestGatewayEnvSetsHermesWorkspace(t *testing.T) {
 	if values["CLAWMANAGER_TEAM_SHARED_DIR"] != "/team" {
 		t.Fatalf("CLAWMANAGER_TEAM_SHARED_DIR = %q, want transparent request value", values["CLAWMANAGER_TEAM_SHARED_DIR"])
 	}
+	if values["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"] != "clawmanager" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_USERNAME = %q, want clawmanager", values["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"])
+	}
+	if values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"] != "secret" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = %q, want secret from CLAWMANAGER_LLM_API_KEY", values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"])
+	}
+}
+
+func TestGatewayEnvPrefersInstanceTokenForDashboardBasicAuth(t *testing.T) {
+	profile := hermes.NewProfile("hermes")
+	req := gateway.CreateGatewayRequest{
+		AgentType:  "hermes",
+		InstanceID: 70,
+		UserID:     45,
+		Environment: map[string]string{
+			"CLAWMANAGER_INSTANCE_TOKEN": "igt_instance_70",
+			"CLAWMANAGER_LLM_API_KEY":    "llm-key-should-not-win",
+		},
+	}
+	workspacePath := "/workspaces/hermes/user-45/instance-70"
+	env := profile.GatewayEnv(nil, gateway.Config{RuntimeType: "hermes", GatewayAuthMode: "trusted-proxy"}, req, workspacePath, 20020)
+	values := envMap(env)
+	if values["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"] != "clawmanager" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_USERNAME = %q, want clawmanager", values["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"])
+	}
+	if values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"] != "igt_instance_70" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = %q, want instance token", values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"])
+	}
+}
+
+func TestGatewayEnvKeepsExplicitHermesDashboardBasicAuth(t *testing.T) {
+	profile := hermes.NewProfile("hermes")
+	req := gateway.CreateGatewayRequest{
+		AgentType:  "hermes",
+		InstanceID: 71,
+		UserID:     45,
+		Environment: map[string]string{
+			"HERMES_DASHBOARD_BASIC_AUTH_USERNAME": "admin",
+			"HERMES_DASHBOARD_BASIC_AUTH_PASSWORD": "explicit-password",
+			"CLAWMANAGER_INSTANCE_TOKEN":          "igt_should_not_override",
+		},
+	}
+	workspacePath := "/workspaces/hermes/user-45/instance-71"
+	env := profile.GatewayEnv(nil, gateway.Config{RuntimeType: "hermes", GatewayAuthMode: "trusted-proxy", GatewayToken: "cfg-token"}, req, workspacePath, 20021)
+	values := envMap(env)
+	if values["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"] != "admin" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_USERNAME = %q, want admin", values["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"])
+	}
+	if values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"] != "explicit-password" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = %q, want explicit-password", values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"])
+	}
+}
+
+func TestGatewayEnvUsesGatewayTokenBeforeRequestAccessToken(t *testing.T) {
+	profile := hermes.NewProfile("hermes")
+	req := gateway.CreateGatewayRequest{
+		AgentType:  "hermes",
+		InstanceID: 72,
+		UserID:     45,
+		Environment: map[string]string{
+			"CLAWMANAGER_INSTANCE_TOKEN": "igt_instance_72",
+		},
+	}
+	workspacePath := "/workspaces/hermes/user-45/instance-72"
+	env := profile.GatewayEnv(nil, gateway.Config{RuntimeType: "hermes", GatewayAuthMode: "token", GatewayToken: "cfg-gateway-token"}, req, workspacePath, 20022)
+	values := envMap(env)
+	if values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"] != "cfg-gateway-token" {
+		t.Fatalf("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = %q, want cfg.GatewayToken", values["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"])
+	}
 }
 
 func TestGatewayEnvMovesDefaultTeamSharedDirIntoWorkspace(t *testing.T) {

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/iamlovingit/clawmanager-agent/internal/gateway"
+	"github.com/iamlovingit/clawmanager-agent/internal/scheduledtasks"
 )
 
 const openClawTrustedProxyUserHeader = "x-forwarded-prefix"
@@ -104,6 +106,33 @@ func WriteGatewayConfig(cfg gateway.Config, req gateway.CreateGatewayRequest, wo
 		if err := gateway.PrepareLiteTeamSharedWorkspace(cfg.WorkspaceRoot, req, workspacePath); err != nil {
 			return err
 		}
+	}
+	openclawHome := filepath.Join(workspacePath, "home", ".openclaw")
+	result := scheduledtasks.ApplyOpenClawFromEnv(openclawHome, func(key string) string {
+		if req.Environment != nil {
+			if value, ok := req.Environment[key]; ok {
+				return value
+			}
+		}
+		if req.Env != nil {
+			if value, ok := req.Env[key]; ok {
+				return value
+			}
+		}
+		return os.Getenv(key)
+	}, req.UID, req.GID)
+	if result.Error != "" {
+		log.Printf("apply openclaw scheduled tasks failed (continuing): source_env=%s error=%s", result.SourceEnv, result.Error)
+	}
+	// Apply writes jobs.json as the agent user (often root). Gateway runs as
+	// instance UID, so chown the whole cron tree — not only the directory inode.
+	cronDir := filepath.Join(openclawHome, "cron")
+	if _, err := os.Stat(cronDir); err == nil {
+		if err := chownTree(cronDir, req.UID, req.GID); err != nil {
+			return fmt.Errorf("chown openclaw cron tree: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat openclaw cron dir: %w", err)
 	}
 	return nil
 }

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_test.go
@@ -427,3 +427,4 @@ func modelIDSet(values []any) map[string]bool {
 	}
 	return out
 }
+

--- a/clawmanager-agent/internal/runtime/openclaw/config_writer_unix_test.go
+++ b/clawmanager-agent/internal/runtime/openclaw/config_writer_unix_test.go
@@ -1,0 +1,80 @@
+//go:build unix
+
+package openclaw
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestWriteOpenClawGatewayConfigChownsScheduledTasksJobsFile(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "openclaw", "user-1", "instance-8")
+	uid := os.Getuid()
+	gid := os.Getgid()
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   1,
+				"type": "scheduled_task",
+				"key":  "daily",
+				"name": "Daily",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "daily",
+						"enabled":       true,
+						"schedule":      map[string]any{"kind": "cron", "expr": "0 9 * * *"},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "brief"},
+						"delivery":      map[string]any{"mode": "announce", "channel": "last"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := CreateGatewayRequest{
+		InstanceID:  8,
+		UserID:      1,
+		UID:         uid,
+		GID:         gid,
+		Environment: map[string]string{"CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON": string(raw)},
+	}
+	cfg := Config{
+		GatewayAuthMode: "trusted-proxy",
+		PublicOrigin:    "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001",
+		AllowedOrigins:  []string{"http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"},
+		TrustedProxies:  []string{"127.0.0.1"},
+		LLMBaseURL:      "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001/api/v1/gateway/llm",
+		LLMAPIKey:       "runtime-llm-token",
+		LLMAPIKeySet:    true,
+		LLMModelIDs:     []string{"gpt-5.5"},
+	}
+	if err := WriteGatewayConfig(cfg, req, workspace); err != nil {
+		t.Fatalf("WriteGatewayConfig() error = %v", err)
+	}
+
+	storePath := filepath.Join(workspace, "home", ".openclaw", "cron", "jobs.json")
+	info, err := os.Stat(storePath)
+	if err != nil {
+		t.Fatalf("stat jobs.json: %v", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("unexpected stat type %T", info.Sys())
+	}
+	if int(stat.Uid) != uid || int(stat.Gid) != gid {
+		t.Fatalf("jobs.json owner = %d:%d, want %d:%d", stat.Uid, stat.Gid, uid, gid)
+	}
+}

--- a/clawmanager-agent/internal/scheduledtasks/apply.go
+++ b/clawmanager-agent/internal/scheduledtasks/apply.go
@@ -1,0 +1,332 @@
+package scheduledtasks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ManagedJobIDPrefix = "cm-st-"
+	EnvHermes          = "CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON"
+	EnvRuntime         = "CLAWMANAGER_RUNTIME_SCHEDULED_TASKS_JSON"
+	EnvOpenClaw        = "CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON"
+)
+
+type PayloadEnvelope struct {
+	SchemaVersion int          `json:"schemaVersion"`
+	Items         []PayloadItem `json:"items"`
+}
+
+type PayloadItem struct {
+	ID      int             `json:"id"`
+	Type    string          `json:"type"`
+	Key     string          `json:"key"`
+	Name    string          `json:"name"`
+	Version int             `json:"version"`
+	Tags    []string        `json:"tags"`
+	Content json.RawMessage `json:"content"`
+}
+
+type ResourceContent struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	Kind          string          `json:"kind"`
+	Format        string          `json:"format"`
+	Config        json.RawMessage `json:"config"`
+}
+
+type CronStoreFile struct {
+	Version int       `json:"version"`
+	Jobs    []CronJob `json:"jobs"`
+}
+
+type CronJob struct {
+	ID            string          `json:"id"`
+	AgentID       string          `json:"agentId,omitempty"`
+	SessionKey    string          `json:"sessionKey,omitempty"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description,omitempty"`
+	Enabled       bool            `json:"enabled"`
+	DeleteAfterRun bool           `json:"deleteAfterRun,omitempty"`
+	CreatedAtMs   int64           `json:"createdAtMs"`
+	UpdatedAtMs   int64           `json:"updatedAtMs"`
+	Schedule      json.RawMessage `json:"schedule"`
+	SessionTarget string          `json:"sessionTarget"`
+	WakeMode      string          `json:"wakeMode"`
+	Payload       json.RawMessage `json:"payload"`
+	Delivery      json.RawMessage `json:"delivery,omitempty"`
+	State         map[string]any  `json:"state"`
+}
+
+type ApplyResult struct {
+	SourceEnv     string   `json:"source_env"`
+	RawSHA256     string   `json:"raw_sha256"`
+	JobCount      int      `json:"job_count"`
+	Skipped       bool     `json:"skipped"`
+	StorePath     string   `json:"store_path"`
+	Error         string   `json:"error,omitempty"`
+	IgnoredFields []string `json:"ignored_fields,omitempty"`
+}
+
+type jobConfig struct {
+	Name           string          `json:"name"`
+	Description    string          `json:"description,omitempty"`
+	Enabled        *bool           `json:"enabled,omitempty"`
+	DeleteAfterRun *bool           `json:"deleteAfterRun,omitempty"`
+	AgentID        string          `json:"agentId,omitempty"`
+	SessionKey     string          `json:"sessionKey,omitempty"`
+	Schedule       json.RawMessage `json:"schedule"`
+	SessionTarget  string          `json:"sessionTarget"`
+	WakeMode       string          `json:"wakeMode"`
+	Payload        json.RawMessage `json:"payload"`
+	Delivery       json.RawMessage `json:"delivery,omitempty"`
+}
+
+// ReadScheduledTasksEnv returns the first non-empty scheduled tasks payload and its env name.
+func ReadScheduledTasksEnv(getenv func(string) string) (envName string, raw string) {
+	for _, key := range []string{EnvHermes, EnvRuntime, EnvOpenClaw} {
+		value := strings.TrimSpace(getenv(key))
+		if value != "" {
+			return key, value
+		}
+	}
+	return "", ""
+}
+
+// ApplyOpenClawFromEnv merges ClawManager managed cron jobs into an OpenClaw cron store.
+// uid/gid should be the instance Linux IDs so gateway processes can read jobs.json.
+func ApplyOpenClawFromEnv(openclawHome string, getenv func(string) string, uid, gid int) ApplyResult {
+	return ApplyFromEnv(OpenClawCronStorePath(openclawHome), getenv, uid, gid)
+}
+
+// ApplyFromEnv merges ClawManager managed cron jobs into storePath (OpenClaw schema).
+func ApplyFromEnv(storePath string, getenv func(string) string, uid, gid int) ApplyResult {
+	result := ApplyResult{StorePath: storePath}
+	envName, raw := ReadScheduledTasksEnv(getenv)
+	if envName == "" {
+		result.Skipped = true
+		return result
+	}
+	result.SourceEnv = envName
+	sum := sha256.Sum256([]byte(raw))
+	result.RawSHA256 = hex.EncodeToString(sum[:])
+
+	jobs, err := jobsFromPayload(raw)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.JobCount = len(jobs)
+
+	existing, err := loadStore(storePath)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if openClawManagedSetMatches(existing.Jobs, jobs, result.RawSHA256) {
+		result.Skipped = true
+		if err := ownCronArtifacts(storePath, uid, gid); err != nil {
+			result.Error = err.Error()
+		}
+		return result
+	}
+
+	if err := upsertManagedJobs(storePath, existing, jobs, result.RawSHA256, uid, gid); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	return result
+}
+
+func openClawManagedSetMatches(existingJobs, managed []CronJob, payloadHash string) bool {
+	existingManaged := map[string]string{}
+	for _, job := range existingJobs {
+		if !strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+			continue
+		}
+		hash := ""
+		if job.State != nil {
+			if value, ok := job.State["clawmanagerPayloadSHA256"].(string); ok {
+				hash = value
+			}
+		}
+		existingManaged[job.ID] = hash
+	}
+	if len(existingManaged) != len(managed) {
+		return false
+	}
+	for _, job := range managed {
+		hash, ok := existingManaged[job.ID]
+		if !ok || hash != payloadHash {
+			return false
+		}
+	}
+	return true
+}
+
+func jobsFromPayload(raw string) ([]CronJob, error) {
+	var payload PayloadEnvelope
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("parse scheduled tasks payload: %w", err)
+	}
+	now := time.Now().UTC().UnixMilli()
+	jobs := make([]CronJob, 0, len(payload.Items))
+	for _, item := range payload.Items {
+		if strings.TrimSpace(strings.ToLower(item.Type)) != "" &&
+			strings.TrimSpace(strings.ToLower(item.Type)) != "scheduled_task" {
+			continue
+		}
+		var content ResourceContent
+		if err := json.Unmarshal(item.Content, &content); err != nil {
+			return nil, fmt.Errorf("parse scheduled task content for id=%d: %w", item.ID, err)
+		}
+		var cfg jobConfig
+		if err := json.Unmarshal(content.Config, &cfg); err != nil {
+			return nil, fmt.Errorf("parse scheduled task config for id=%d: %w", item.ID, err)
+		}
+		name := strings.TrimSpace(cfg.Name)
+		if name == "" {
+			name = strings.TrimSpace(item.Name)
+		}
+		if name == "" {
+			name = item.Key
+		}
+		enabled := true
+		if cfg.Enabled != nil {
+			enabled = *cfg.Enabled
+		}
+		deleteAfterRun := false
+		if cfg.DeleteAfterRun != nil {
+			deleteAfterRun = *cfg.DeleteAfterRun
+		}
+		jobID := ManagedJobIDPrefix + strconv.Itoa(item.ID)
+		jobs = append(jobs, CronJob{
+			ID:             jobID,
+			AgentID:        strings.TrimSpace(cfg.AgentID),
+			SessionKey:     strings.TrimSpace(cfg.SessionKey),
+			Name:           name,
+			Description:    cfg.Description,
+			Enabled:        enabled,
+			DeleteAfterRun: deleteAfterRun,
+			CreatedAtMs:    now,
+			UpdatedAtMs:    now,
+			Schedule:       cfg.Schedule,
+			SessionTarget:  strings.TrimSpace(cfg.SessionTarget),
+			WakeMode:       strings.TrimSpace(cfg.WakeMode),
+			Payload:        cfg.Payload,
+			Delivery:       cfg.Delivery,
+			State:          map[string]any{},
+		})
+	}
+	return jobs, nil
+}
+
+func upsertManagedJobs(storePath string, existing CronStoreFile, managed []CronJob, payloadHash string, uid, gid int) error {
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o750); err != nil {
+		return fmt.Errorf("create cron store dir: %w", err)
+	}
+	if err := ownPath(filepath.Dir(storePath), uid, gid); err != nil {
+		return err
+	}
+
+	kept := make([]CronJob, 0, len(existing.Jobs))
+	for _, job := range existing.Jobs {
+		if strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+			continue
+		}
+		kept = append(kept, job)
+	}
+
+	now := time.Now().UTC().UnixMilli()
+	existingByID := map[string]CronJob{}
+	for _, job := range existing.Jobs {
+		existingByID[job.ID] = job
+	}
+	for _, job := range managed {
+		if prev, ok := existingByID[job.ID]; ok {
+			job.CreatedAtMs = prev.CreatedAtMs
+			if prev.State != nil {
+				job.State = prev.State
+			}
+		} else {
+			job.CreatedAtMs = now
+		}
+		job.UpdatedAtMs = now
+		if job.State == nil {
+			job.State = map[string]any{}
+		}
+		job.State["clawmanagerPayloadSHA256"] = payloadHash
+		kept = append(kept, job)
+	}
+
+	next := CronStoreFile{Version: 1, Jobs: kept}
+	return saveStore(storePath, next, uid, gid)
+}
+
+func loadStore(path string) (CronStoreFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CronStoreFile{Version: 1, Jobs: []CronJob{}}, nil
+		}
+		return CronStoreFile{}, fmt.Errorf("read cron store: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return CronStoreFile{Version: 1, Jobs: []CronJob{}}, nil
+	}
+	var store CronStoreFile
+	if err := json.Unmarshal(data, &store); err != nil {
+		return CronStoreFile{}, fmt.Errorf("parse cron store: %w", err)
+	}
+	if store.Version == 0 {
+		store.Version = 1
+	}
+	if store.Jobs == nil {
+		store.Jobs = []CronJob{}
+	}
+	return store, nil
+}
+
+func saveStore(path string, store CronStoreFile, uid, gid int) error {
+	raw, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cron store: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(raw, '\n'), 0o640); err != nil {
+		return fmt.Errorf("write cron store temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace cron store: %w", err)
+	}
+	return ownCronArtifacts(path, uid, gid)
+}
+
+func ownCronArtifacts(storePath string, uid, gid int) error {
+	if err := ownPath(filepath.Dir(storePath), uid, gid); err != nil {
+		return err
+	}
+	if _, err := os.Stat(storePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return ownPath(storePath, uid, gid)
+}
+
+// OpenClawCronStorePath returns the OpenClaw cron jobs.json under openclawHome.
+func OpenClawCronStorePath(openclawHome string) string {
+	return filepath.Join(openclawHome, "cron", "jobs.json")
+}
+
+// HermesCronStorePath returns the Hermes cron jobs.json under hermesHome.
+func HermesCronStorePath(hermesHome string) string {
+	return filepath.Join(hermesHome, "cron", "jobs.json")
+}

--- a/clawmanager-agent/internal/scheduledtasks/apply_test.go
+++ b/clawmanager-agent/internal/scheduledtasks/apply_test.go
@@ -1,0 +1,150 @@
+package scheduledtasks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyOpenClawFromEnvUpsertsManagedJobs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	openclawHome := filepath.Join(dir, ".openclaw")
+
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   7,
+				"type": "scheduled_task",
+				"key":  "daily",
+				"name": "Daily",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "daily",
+						"enabled":       true,
+						"schedule":      map[string]any{"kind": "cron", "expr": "0 9 * * *"},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "brief"},
+						"delivery":      map[string]any{"mode": "announce", "channel": "last"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvOpenClaw: string(raw)}
+	result := ApplyOpenClawFromEnv(openclawHome, func(key string) string { return env[key] }, 0, 0)
+	if result.Error != "" {
+		t.Fatalf("apply error: %s", result.Error)
+	}
+	if result.JobCount != 1 {
+		t.Fatalf("job count = %d", result.JobCount)
+	}
+	store, err := loadStore(OpenClawCronStorePath(openclawHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Jobs) != 1 || store.Jobs[0].ID != "cm-st-7" {
+		t.Fatalf("unexpected jobs: %+v", store.Jobs)
+	}
+	if !strings.Contains(string(store.Jobs[0].Delivery), `"mode"`) ||
+		!strings.Contains(string(store.Jobs[0].Delivery), `announce`) {
+		t.Fatalf("delivery not preserved: %s", string(store.Jobs[0].Delivery))
+	}
+
+	second := ApplyOpenClawFromEnv(openclawHome, func(key string) string { return env[key] }, 0, 0)
+	if second.Error != "" {
+		t.Fatalf("second apply error: %s", second.Error)
+	}
+	if !second.Skipped {
+		t.Fatal("expected second identical apply to skip")
+	}
+}
+
+func TestApplyHermesFromEnvTranslatesWebhookAndAnnounce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	hermesHome := filepath.Join(dir, ".hermes")
+
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   9,
+				"type": "scheduled_task",
+				"key":  "hook",
+				"name": "Hook",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "hook",
+						"schedule":      map[string]any{"kind": "every", "everyMs": 120000},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "ping"},
+						"delivery":      map[string]any{"mode": "webhook", "to": "https://example.com/h"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvHermes: string(raw)}
+	result := ApplyHermesFromEnv(hermesHome, func(key string) string { return env[key] }, 0, 0)
+	if result.Error != "" {
+		t.Fatalf("apply error: %s", result.Error)
+	}
+	file, err := loadHermesJobs(HermesCronStorePath(hermesHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(file.Jobs) != 1 {
+		t.Fatalf("jobs=%d", len(file.Jobs))
+	}
+	job := file.Jobs[0]
+	if job.ID != "cm-st-9" {
+		t.Fatalf("id=%s", job.ID)
+	}
+	if job.Deliver != "local" {
+		t.Fatalf("deliver=%s", job.Deliver)
+	}
+	if job.Schedule["kind"] != "interval" {
+		t.Fatalf("schedule=%v", job.Schedule)
+	}
+	if !strings.Contains(job.Prompt, "https://example.com/h") {
+		t.Fatalf("webhook instruction missing: %s", job.Prompt)
+	}
+	webhookFile := filepath.Join(hermesHome, "cron", "webhooks", "cm-st-9.url")
+	data, err := os.ReadFile(webhookFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "https://example.com/h" {
+		t.Fatalf("webhook file=%q", string(data))
+	}
+	if len(result.IgnoredFields) == 0 {
+		t.Fatal("expected ignored_fields for hermes translation")
+	}
+	second := ApplyHermesFromEnv(hermesHome, func(key string) string { return env[key] }, 0, 0)
+	if second.Error != "" {
+		t.Fatalf("second hermes apply error: %s", second.Error)
+	}
+	if !second.Skipped {
+		t.Fatal("expected second identical hermes apply to skip")
+	}
+}

--- a/clawmanager-agent/internal/scheduledtasks/apply_unix_test.go
+++ b/clawmanager-agent/internal/scheduledtasks/apply_unix_test.go
@@ -1,0 +1,140 @@
+//go:build unix
+
+package scheduledtasks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestApplyOpenClawFromEnvOwnsJobsFile(t *testing.T) {
+	t.Parallel()
+	uid := os.Getuid()
+	gid := os.Getgid()
+	if uid <= 0 || gid <= 0 {
+		t.Skip("need positive uid/gid for ownership assertions")
+	}
+
+	openclawHome := filepath.Join(t.TempDir(), ".openclaw")
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   7,
+				"type": "scheduled_task",
+				"key":  "daily",
+				"name": "Daily",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "daily",
+						"enabled":       true,
+						"schedule":      map[string]any{"kind": "cron", "expr": "0 9 * * *"},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "brief"},
+						"delivery":      map[string]any{"mode": "announce", "channel": "last"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvOpenClaw: string(raw)}
+	result := ApplyOpenClawFromEnv(openclawHome, func(key string) string { return env[key] }, uid, gid)
+	if result.Error != "" {
+		t.Fatalf("apply error: %s", result.Error)
+	}
+	if result.Skipped {
+		t.Fatal("expected first apply to write jobs, not skip")
+	}
+
+	storePath := OpenClawCronStorePath(openclawHome)
+	assertOwnedMode(t, storePath, uid, gid, 0o640)
+	assertOwnedMode(t, filepath.Dir(storePath), uid, gid, -1)
+}
+
+func TestApplyHermesFromEnvOwnsJobsAndWebhook(t *testing.T) {
+	t.Parallel()
+	uid := os.Getuid()
+	gid := os.Getgid()
+	if uid <= 0 || gid <= 0 {
+		t.Skip("need positive uid/gid for ownership assertions")
+	}
+
+	hermesHome := filepath.Join(t.TempDir(), ".hermes")
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   9,
+				"type": "scheduled_task",
+				"key":  "hook",
+				"name": "Hook",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "hook",
+						"schedule":      map[string]any{"kind": "every", "everyMs": 120000},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "ping"},
+						"delivery":      map[string]any{"mode": "webhook", "to": "https://example.com/h"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvHermes: string(raw)}
+	result := ApplyHermesFromEnv(hermesHome, func(key string) string { return env[key] }, uid, gid)
+	if result.Error != "" {
+		t.Fatalf("apply error: %s", result.Error)
+	}
+	if result.Skipped {
+		t.Fatal("expected first hermes apply to write jobs, not skip")
+	}
+
+	storePath := HermesCronStorePath(hermesHome)
+	assertOwnedMode(t, storePath, uid, gid, 0o640)
+
+	hashPath := filepath.Join(hermesHome, "cron", "clawmanager-scheduled-tasks.sha256")
+	assertOwnedMode(t, hashPath, uid, gid, 0o640)
+
+	webhookPath := filepath.Join(hermesHome, "cron", "webhooks", "cm-st-9.url")
+	assertOwnedMode(t, webhookPath, uid, gid, 0o640)
+}
+
+func assertOwnedMode(t *testing.T, path string, uid, gid, wantMode int) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat %s: unexpected Sys type %T", path, info.Sys())
+	}
+	if int(stat.Uid) != uid || int(stat.Gid) != gid {
+		t.Fatalf("owner %s = %d:%d, want %d:%d", path, stat.Uid, stat.Gid, uid, gid)
+	}
+	if wantMode >= 0 {
+		got := info.Mode().Perm()
+		if got != os.FileMode(wantMode) {
+			t.Fatalf("mode %s = %o, want %o", path, got, wantMode)
+		}
+	}
+}

--- a/clawmanager-agent/internal/scheduledtasks/hermes.go
+++ b/clawmanager-agent/internal/scheduledtasks/hermes.go
@@ -1,0 +1,454 @@
+package scheduledtasks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type HermesJobsFile struct {
+	Jobs      []HermesJob `json:"jobs"`
+	UpdatedAt string      `json:"updated_at,omitempty"`
+}
+
+type HermesJob struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Prompt      string         `json:"prompt"`
+	Schedule    map[string]any `json:"schedule"`
+	Skills      []string       `json:"skills"`
+	Skill       any            `json:"skill"`
+	Deliver     string         `json:"deliver"`
+	Repeat      map[string]any `json:"repeat"`
+	State       string         `json:"state"`
+	Enabled     bool           `json:"enabled"`
+	NextRunAt   *string        `json:"next_run_at"`
+	LastRunAt   any            `json:"last_run_at"`
+	LastStatus  any            `json:"last_status"`
+	CreatedAt   string         `json:"created_at"`
+	Model       any            `json:"model"`
+	Provider    any            `json:"provider"`
+	Script      any            `json:"script"`
+	ScheduleDisplay string     `json:"schedule_display,omitempty"`
+}
+
+// ApplyHermesFromEnv translates OpenClaw-benchmark scheduled tasks into Hermes
+// native cron jobs and upserts managed entries into hermes jobs.json.
+// uid/gid should be the instance Linux IDs so gateway processes can read the store.
+func ApplyHermesFromEnv(hermesHome string, getenv func(string) string, uid, gid int) ApplyResult {
+	storePath := HermesCronStorePath(hermesHome)
+	result := ApplyResult{
+		StorePath:     storePath,
+		IgnoredFields: []string{"wakeMode", "sessionTarget"},
+	}
+	envName, raw := ReadScheduledTasksEnv(getenv)
+	if envName == "" {
+		result.Skipped = true
+		return result
+	}
+	result.SourceEnv = envName
+	sum := sha256Sum(raw)
+	result.RawSHA256 = sum
+
+	hashPath := filepath.Join(hermesHome, "cron", "clawmanager-scheduled-tasks.sha256")
+	if previous, err := os.ReadFile(hashPath); err == nil && strings.TrimSpace(string(previous)) == sum {
+		existing, loadErr := loadHermesJobs(storePath)
+		if loadErr == nil {
+			managedCount := 0
+			for _, job := range existing.Jobs {
+				if strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+					managedCount++
+				}
+			}
+			openClawJobs, parseErr := jobsFromPayload(raw)
+			if parseErr == nil && managedCount == len(openClawJobs) {
+				result.JobCount = len(openClawJobs)
+				result.Skipped = true
+				if err := ownHermesCronArtifacts(hermesHome, storePath, hashPath, uid, gid); err != nil {
+					result.Error = err.Error()
+				}
+				return result
+			}
+		}
+	}
+
+	openClawJobs, err := jobsFromPayload(raw)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	hermesJobs := make([]HermesJob, 0, len(openClawJobs))
+	for _, job := range openClawJobs {
+		hj, err := translateOpenClawJobToHermes(job, hermesHome, uid, gid)
+		if err != nil {
+			result.Error = err.Error()
+			return result
+		}
+		hermesJobs = append(hermesJobs, hj)
+	}
+	result.JobCount = len(hermesJobs)
+	if err := upsertHermesManagedJobs(storePath, hermesJobs, uid, gid); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := os.MkdirAll(filepath.Dir(hashPath), 0o750); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := ownPath(filepath.Dir(hashPath), uid, gid); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := os.WriteFile(hashPath, []byte(sum+"\n"), 0o640); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := ownHermesCronArtifacts(hermesHome, storePath, hashPath, uid, gid); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	return result
+}
+
+func translateOpenClawJobToHermes(job CronJob, hermesHome string, uid, gid int) (HermesJob, error) {
+	prompt, model, err := extractHermesPrompt(job)
+	if err != nil {
+		return HermesJob{}, err
+	}
+	schedule, display, err := translateScheduleToHermes(job.Schedule)
+	if err != nil {
+		return HermesJob{}, err
+	}
+	deliver, webhookURL, err := translateDeliveryToHermes(job.Delivery)
+	if err != nil {
+		return HermesJob{}, err
+	}
+	if webhookURL != "" {
+		prompt = appendWebhookInstruction(prompt, webhookURL)
+		if err := writeHermesWebhookURL(hermesHome, job.ID, webhookURL, uid, gid); err != nil {
+			return HermesJob{}, err
+		}
+	}
+
+	now := time.Now().UTC()
+	created := now.Format(time.RFC3339)
+	next := computeHermesNextRunHint(schedule, now)
+	hj := HermesJob{
+		ID:              job.ID,
+		Name:            job.Name,
+		Prompt:          prompt,
+		Schedule:        schedule,
+		Skills:          []string{},
+		Skill:           nil,
+		Deliver:         deliver,
+		Repeat:          map[string]any{"times": nil, "completed": 0},
+		State:           "scheduled",
+		Enabled:         job.Enabled,
+		NextRunAt:       next,
+		LastRunAt:       nil,
+		LastStatus:      nil,
+		CreatedAt:       created,
+		Model:           model,
+		Provider:        nil,
+		Script:          nil,
+		ScheduleDisplay: display,
+	}
+	if !job.Enabled {
+		hj.State = "paused"
+	}
+	if job.DeleteAfterRun {
+		hj.Repeat = map[string]any{"times": 1, "completed": 0}
+	}
+	return hj, nil
+}
+
+func extractHermesPrompt(job CronJob) (string, any, error) {
+	var payload map[string]any
+	if err := json.Unmarshal(job.Payload, &payload); err != nil {
+		return "", nil, fmt.Errorf("hermes translate payload: %w", err)
+	}
+	kind, _ := payload["kind"].(string)
+	var model any
+	if value, ok := payload["model"]; ok {
+		model = value
+	}
+	switch kind {
+	case "agentTurn":
+		message, _ := payload["message"].(string)
+		if strings.TrimSpace(message) == "" {
+			return "", nil, fmt.Errorf("hermes translate: agentTurn message required")
+		}
+		return message, model, nil
+	case "systemEvent":
+		text, _ := payload["text"].(string)
+		if strings.TrimSpace(text) == "" {
+			return "", nil, fmt.Errorf("hermes translate: systemEvent text required")
+		}
+		// Hermes cron always runs an agent prompt; mirror systemEvent as explicit instruction.
+		return "System event (from ClawManager scheduled task):\n" + text, model, nil
+	default:
+		return "", nil, fmt.Errorf("hermes translate: unsupported payload.kind %q", kind)
+	}
+}
+
+func translateScheduleToHermes(raw json.RawMessage) (map[string]any, string, error) {
+	var schedule map[string]any
+	if err := json.Unmarshal(raw, &schedule); err != nil {
+		return nil, "", fmt.Errorf("hermes translate schedule: %w", err)
+	}
+	kind, _ := schedule["kind"].(string)
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "cron":
+		expr, _ := schedule["expr"].(string)
+		expr = strings.TrimSpace(expr)
+		if expr == "" {
+			return nil, "", fmt.Errorf("hermes translate: cron expr required")
+		}
+		return map[string]any{
+			"kind":    "cron",
+			"expr":    expr,
+			"display": expr,
+		}, expr, nil
+	case "every":
+		everyMs, err := asInt64(schedule["everyMs"])
+		if err != nil || everyMs <= 0 {
+			return nil, "", fmt.Errorf("hermes translate: everyMs must be > 0")
+		}
+		minutes := everyMs / 60000
+		if minutes < 1 {
+			minutes = 1
+		}
+		display := fmt.Sprintf("every %dm", minutes)
+		return map[string]any{
+			"kind":    "interval",
+			"minutes": minutes,
+			"display": display,
+		}, display, nil
+	case "at":
+		at, _ := schedule["at"].(string)
+		at = strings.TrimSpace(at)
+		if at == "" {
+			return nil, "", fmt.Errorf("hermes translate: at timestamp required")
+		}
+		display := "once at " + at
+		return map[string]any{
+			"kind":    "once",
+			"run_at":  at,
+			"display": display,
+		}, display, nil
+	default:
+		return nil, "", fmt.Errorf("hermes translate: unsupported schedule.kind %q", kind)
+	}
+}
+
+func translateDeliveryToHermes(raw json.RawMessage) (deliver string, webhookURL string, err error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "origin", "", nil
+	}
+	var delivery map[string]any
+	if err := json.Unmarshal(raw, &delivery); err != nil {
+		return "", "", fmt.Errorf("hermes translate delivery: %w", err)
+	}
+	mode, _ := delivery["mode"].(string)
+	channel, _ := delivery["channel"].(string)
+	to, _ := delivery["to"].(string)
+	channel = strings.TrimSpace(channel)
+	to = strings.TrimSpace(to)
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "announce":
+		if channel == "" || channel == "last" {
+			return "origin", "", nil
+		}
+		if to != "" {
+			return channel + ":" + to, "", nil
+		}
+		return channel, "", nil
+	case "none":
+		return "local", "", nil
+	case "webhook":
+		if to == "" {
+			return "", "", fmt.Errorf("hermes translate: webhook delivery.to required")
+		}
+		return "local", to, nil
+	default:
+		return "", "", fmt.Errorf("hermes translate: unsupported delivery.mode %q", mode)
+	}
+}
+
+func appendWebhookInstruction(prompt, webhookURL string) string {
+	return prompt + "\n\n[ClawManager delivery.webhook]\n" +
+		"After you finish, POST your complete final answer as JSON {\"text\": \"...\"} to " +
+		webhookURL +
+		" using an available HTTP tool. Treat webhook delivery as required."
+}
+
+func writeHermesWebhookURL(hermesHome, jobID, webhookURL string, uid, gid int) error {
+	dir := filepath.Join(hermesHome, "cron", "webhooks")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	if err := ownPath(dir, uid, gid); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, jobID+".url")
+	if err := os.WriteFile(path, []byte(webhookURL+"\n"), 0o640); err != nil {
+		return err
+	}
+	return ownPath(path, uid, gid)
+}
+
+func computeHermesNextRunHint(schedule map[string]any, now time.Time) *string {
+	kind, _ := schedule["kind"].(string)
+	switch kind {
+	case "once":
+		if runAt, ok := schedule["run_at"].(string); ok && strings.TrimSpace(runAt) != "" {
+			value := strings.TrimSpace(runAt)
+			return &value
+		}
+	case "interval", "cron":
+		value := now.UTC().Format(time.RFC3339)
+		return &value
+	}
+	value := now.UTC().Format(time.RFC3339)
+	return &value
+}
+
+func upsertHermesManagedJobs(storePath string, managed []HermesJob, uid, gid int) error {
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o750); err != nil {
+		return fmt.Errorf("create hermes cron dir: %w", err)
+	}
+	if err := ownPath(filepath.Dir(storePath), uid, gid); err != nil {
+		return err
+	}
+	existing, err := loadHermesJobs(storePath)
+	if err != nil {
+		return err
+	}
+	kept := make([]HermesJob, 0, len(existing.Jobs))
+	existingByID := map[string]HermesJob{}
+	for _, job := range existing.Jobs {
+		existingByID[job.ID] = job
+		if strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+			continue
+		}
+		kept = append(kept, job)
+	}
+	for _, job := range managed {
+		if prev, ok := existingByID[job.ID]; ok {
+			job.CreatedAt = prev.CreatedAt
+			job.LastRunAt = prev.LastRunAt
+			job.LastStatus = prev.LastStatus
+			if prev.Repeat != nil {
+				if completed, ok := prev.Repeat["completed"]; ok {
+					job.Repeat["completed"] = completed
+				}
+			}
+		}
+		kept = append(kept, job)
+	}
+	return saveHermesJobs(storePath, HermesJobsFile{
+		Jobs:      kept,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}, uid, gid)
+}
+
+func loadHermesJobs(path string) (HermesJobsFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return HermesJobsFile{Jobs: []HermesJob{}}, nil
+		}
+		return HermesJobsFile{}, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return HermesJobsFile{Jobs: []HermesJob{}}, nil
+	}
+	var asObject HermesJobsFile
+	if err := json.Unmarshal(data, &asObject); err == nil {
+		if asObject.Jobs == nil {
+			asObject.Jobs = []HermesJob{}
+		}
+		return asObject, nil
+	}
+	var asList []HermesJob
+	if err := json.Unmarshal(data, &asList); err != nil {
+		return HermesJobsFile{}, fmt.Errorf("parse hermes cron store: %w", err)
+	}
+	return HermesJobsFile{Jobs: asList}, nil
+}
+
+func saveHermesJobs(path string, file HermesJobsFile, uid, gid int) error {
+	raw, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(raw, '\n'), 0o640); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	return ownPath(path, uid, gid)
+}
+
+func ownHermesCronArtifacts(hermesHome, storePath, hashPath string, uid, gid int) error {
+	for _, path := range []string{
+		filepath.Join(hermesHome, "cron"),
+		storePath,
+		hashPath,
+		filepath.Join(hermesHome, "cron", "webhooks"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := ownPath(path, uid, gid); err != nil {
+			return err
+		}
+	}
+	webhooksDir := filepath.Join(hermesHome, "cron", "webhooks")
+	entries, err := os.ReadDir(webhooksDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if err := ownPath(filepath.Join(webhooksDir, entry.Name()), uid, gid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func asInt64(value any) (int64, error) {
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed), nil
+	case int64:
+		return typed, nil
+	case int:
+		return int64(typed), nil
+	case json.Number:
+		return typed.Int64()
+	case string:
+		return strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+	default:
+		return 0, fmt.Errorf("not an int")
+	}
+}
+
+func sha256Sum(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/clawmanager-agent/internal/scheduledtasks/owner.go
+++ b/clawmanager-agent/internal/scheduledtasks/owner.go
@@ -1,0 +1,22 @@
+package scheduledtasks
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// ownPath sets uid:gid on path when both ids are positive.
+// No-op on Windows (os.Chown is unsupported for this use-case).
+func ownPath(path string, uid, gid int) error {
+	if uid <= 0 || gid <= 0 {
+		return nil
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", path, err)
+	}
+	return nil
+}

--- a/hermes/Dockerfile.agent-overlay.nosyntax
+++ b/hermes/Dockerfile.agent-overlay.nosyntax
@@ -7,7 +7,7 @@
 
 ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
 
-FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS clawmanager-agent-builder
 
 WORKDIR /src/clawmanager-agent
 

--- a/hermes/Dockerfile.agent-patch
+++ b/hermes/Dockerfile.agent-patch
@@ -1,0 +1,3 @@
+FROM ghcr.io/yuan-lab-llm/agentsruntime/hermes:v2026.6.12
+COPY clawmanager-agent/clawmanager-agent-linux /usr/local/bin/clawmanager-agent
+RUN chmod 755 /usr/local/bin/clawmanager-agent

--- a/hermes/Dockerfile.nosyntax
+++ b/hermes/Dockerfile.nosyntax
@@ -1,0 +1,146 @@
+﻿
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+
+WORKDIR /src/clawmanager-agent
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+COPY clawmanager-agent ./
+RUN go mod download
+
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+        go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+FROM lscr.io/linuxserver/webtop:ubuntu-kde
+
+ARG HERMES_BRANCH=main
+ARG NODE_MAJOR=22
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV HERMES_HOME=/config/.hermes \
+    HERMES_SKILL_DIRS=/config/hermes/skills:/config/.hermes/skills \
+    CLAWMANAGER_RUNTIME_TYPE=hermes \
+    PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/ms-playwright \
+    PUID=1000 \
+    PGID=1000 \
+    TITLE="Hermes Runtime" \
+    SUBFOLDER="/" \
+    PATH=/opt/node/bin:/usr/local/bin:${PATH}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        ffmpeg \
+        git \
+        libffi-dev \
+        libjpeg-dev \
+        libolm-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        openssh-client \
+        pkg-config \
+        portaudio19-dev \
+        ripgrep \
+        sudo \
+        tar \
+        unzip \
+        xz-utils \
+        zlib1g-dev; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "${arch}" in \
+        amd64|x86_64) node_arch="x64" ;; \
+        arm64|aarch64) node_arch="arm64" ;; \
+        arm|armhf) node_arch="armv7l" ;; \
+        *) echo "Unsupported architecture for Node.js: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    node_index="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/"; \
+    node_tar="$(curl -fsSL "${node_index}" | grep -oE "node-v${NODE_MAJOR}\.[0-9]+\.[0-9]+-linux-${node_arch}\.tar\.xz" | head -1)"; \
+    test -n "${node_tar}"; \
+    curl -fsSL "${node_index}${node_tar}" -o /tmp/node.tar.xz; \
+    mkdir -p /opt/node; \
+    tar -xJf /tmp/node.tar.xz -C /opt/node --strip-components=1; \
+    ln -sf /opt/node/bin/node /usr/local/bin/node; \
+    ln -sf /opt/node/bin/npm /usr/local/bin/npm; \
+    ln -sf /opt/node/bin/npx /usr/local/bin/npx; \
+    node --version; \
+    npm --version; \
+    rm -f /tmp/node.tar.xz
+
+RUN set -eux; \
+    mkdir -p "${HERMES_HOME}" "${PLAYWRIGHT_BROWSERS_PATH}"; \
+    export HOME=/root; \
+    curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
+        | bash -s -- --branch "${HERMES_BRANCH}" --hermes-home "${HERMES_HOME}" --skip-setup; \
+    /usr/local/lib/hermes-agent/venv/bin/python -m ensurepip --upgrade; \
+    /usr/local/lib/hermes-agent/venv/bin/python -m pip install --no-cache-dir "hermes-agent[dingtalk,messaging,matrix,wecom]"; \
+    cd /usr/local/lib/hermes-agent; \
+    npm install --workspace web; \
+    npm install --workspace ui-tui; \
+    npm run build -w web; \
+    npm run build -w ui-tui; \
+    test -d /usr/local/lib/hermes-agent/hermes_cli/web_dist; \
+    test -f /usr/local/lib/hermes-agent/ui-tui/dist/entry.js; \
+    chmod -R a+rX /usr/local/lib/hermes-agent "${PLAYWRIGHT_BROWSERS_PATH}"; \
+    chown -R abc:abc "${HERMES_HOME}" || true; \
+    hermes --help >/dev/null; \
+    rm -rf /root/.cache /root/.npm /tmp/*
+
+COPY --from=clawmanager-agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+# Canonical source lives at plugins/hermes-redis-team. This vendor copy keeps
+# the Hermes image build independent from plugin workspace layout changes.
+COPY hermes/vendor-plugins/redis_team/ /tmp/hermes-vendor-plugins/redis_team/
+COPY hermes/rootfs/ /
+
+ENV SHELL=/bin/bash
+
+RUN set -eux; \
+    hermes_python="$(readlink -f /usr/local/lib/hermes-agent/venv/bin/python)"; \
+    hermes_python_root="$(dirname "$(dirname "${hermes_python}")")"; \
+    hermes_new_python_root="/opt/uv/python/$(basename "${hermes_python_root}")"; \
+    mkdir -p /opt/uv/python /usr/local/lib/hermes-agent/plugins/platforms/redis_team; \
+    cp -a "${hermes_python_root}" /opt/uv/python/; \
+    ln -sfn "${hermes_new_python_root}/bin/$(basename "${hermes_python}")" /usr/local/lib/hermes-agent/venv/bin/python; \
+    sed -i "s|/root/.local/share/uv/python/[^/]*/bin|${hermes_new_python_root}/bin|g" /usr/local/lib/hermes-agent/venv/pyvenv.cfg; \
+    chmod -R a+rX /opt/uv /usr/local/lib/hermes-agent/venv; \
+    rm -rf /root/.local/share/uv/python; \
+    cp -a /tmp/hermes-vendor-plugins/redis_team/. /usr/local/lib/hermes-agent/plugins/platforms/redis_team/; \
+    chmod -R a+rX /usr/local/lib/hermes-agent/plugins/platforms/redis_team; \
+    rm -rf /tmp/hermes-vendor-plugins; \
+    find /etc/s6-overlay/s6-rc.d -type f -exec sed -i 's/\r$//' {} +; \
+    sed -i 's/\r$//' \
+        /usr/local/bin/wrapped-chromium \
+        /usr/local/bin/hermes-apply-runtime-config \
+        /usr/local/bin/start-hermes-dashboard-gateway \
+        /usr/local/bin/start-hermes-terminal \
+        /usr/local/bin/start-hermes-gateway \
+        /custom-cont-init.d/99-hermes-config \
+        /etc/s6-overlay/s6-rc.d/hermes-agent/run \
+        /etc/s6-overlay/s6-rc.d/hermes-gateway/run; \
+    chmod 755 \
+        /usr/local/bin/wrapped-chromium \
+        /usr/local/bin/clawmanager-agent \
+        /usr/local/bin/hermes-apply-runtime-config \
+        /usr/local/bin/start-hermes-dashboard-gateway \
+        /usr/local/bin/start-hermes-terminal \
+        /usr/local/bin/start-hermes-gateway \
+        /custom-cont-init.d/99-hermes-config \
+        /etc/s6-overlay/s6-rc.d/hermes-agent/run \
+        /etc/s6-overlay/s6-rc.d/hermes-gateway/run
+
+EXPOSE 3001

--- a/hermes/Dockerfile.pro-overlay.nosyntax
+++ b/hermes/Dockerfile.pro-overlay.nosyntax
@@ -1,0 +1,33 @@
+# Local smoke: published Hermes Pro + clawmanager-agent + hermes-apply-runtime-config.
+#
+#   docker build -f hermes/Dockerfile.pro-overlay.nosyntax \
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes:latest \
+#     -t hermes:local .
+
+ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/hermes:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS clawmanager-agent-builder
+
+WORKDIR /src/clawmanager-agent
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+COPY clawmanager-agent ./
+RUN go mod download
+
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+        go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+FROM ${BASE_IMAGE}
+COPY --from=clawmanager-agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+COPY hermes/rootfs/usr/local/bin/hermes-apply-runtime-config /usr/local/bin/hermes-apply-runtime-config
+COPY hermes/rootfs/usr/local/bin/start-hermes-gateway /usr/local/bin/start-hermes-gateway
+RUN sed -i 's/\r$//' /usr/local/bin/hermes-apply-runtime-config /usr/local/bin/start-hermes-gateway \
+  && chmod 755 /usr/local/bin/clawmanager-agent \
+    /usr/local/bin/hermes-apply-runtime-config \
+    /usr/local/bin/start-hermes-gateway

--- a/hermes/hermes-runtime-agent-development.md
+++ b/hermes/hermes-runtime-agent-development.md
@@ -144,6 +144,14 @@ Hermes agent 需要同时处理两类注入：
 | Agents | `CLAWMANAGER_HERMES_AGENTS_JSON` | `CLAWMANAGER_RUNTIME_AGENTS_JSON`，`CLAWMANAGER_OPENCLAW_AGENTS_JSON` |
 | Scheduled Tasks | `CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON` | `CLAWMANAGER_RUNTIME_SCHEDULED_TASKS_JSON`，`CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON` |
 
+Scheduled Task 使用 OpenClaw cron 标杆（`schedule` + `payload` + `delivery`，format=`task/openclaw-cron@v1`）。Hermes 启动时会把该 JSON **翻译**为原生 `~/.hermes/cron/jobs.json`（托管 id `cm-st-*`），由 gateway 内置 cron 执行。`announce` 映射为 Hermes `deliver`；`webhook` 映射为 `deliver=local` + prompt 内必填 POST 说明，并写入 `cron/webhooks/cm-st-*.url`。
+
+补充说明：
+
+- apply 为 soft-fail：解析/翻译失败写入 bootstrap `scheduled-tasks` 状态，不中断启动。
+- 相同 payload sha256 且 managed job 数量一致时跳过重写 `jobs.json`。
+- OpenClaw 字段 `wakeMode` / `sessionTarget` 在 Hermes 侧故意忽略（`ignored_fields`）；Hermes cron 始终使用全新 agent 会话。平台资源仍保留这些字段以兼容 OpenClaw。
+
 如果某个变量不存在或为空，按空配置处理，不要让 agent 启动失败。只有变量存在但 JSON 无法解析时，agent 应记录清晰错误，并在 state report 的 `health.bootstrap_config` 或 `health.config_loader` 中标记为 `error`。
 
 建议 agent 把本次读取到的原始 JSON、解析后的配置和 hash 写入：

--- a/hermes/rootfs/usr/local/bin/hermes-apply-runtime-config
+++ b/hermes/rootfs/usr/local/bin/hermes-apply-runtime-config
@@ -48,6 +48,11 @@ BOOTSTRAP_ENV_NAMES = {
         "CLAWMANAGER_RUNTIME_SKILLS_JSON",
         "CLAWMANAGER_OPENCLAW_SKILLS_JSON",
     ),
+    "scheduled_tasks": (
+        "CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON",
+        "CLAWMANAGER_RUNTIME_SCHEDULED_TASKS_JSON",
+        "CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON",
+    ),
 }
 
 
@@ -1401,6 +1406,240 @@ def apply_bootstrap_manifest(hermes_home):
     return record
 
 
+MANAGED_JOB_PREFIX = "cm-st-"
+
+
+def _as_int(value, default=0):
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _translate_schedule(schedule):
+    if not isinstance(schedule, dict):
+        raise ValueError("schedule must be an object")
+    kind = str(schedule.get("kind") or "").strip().lower()
+    if kind == "cron":
+        expr = str(schedule.get("expr") or "").strip()
+        if not expr:
+            raise ValueError("cron expr required")
+        return {"kind": "cron", "expr": expr, "display": expr}, expr
+    if kind == "every":
+        every_ms = _as_int(schedule.get("everyMs"), 0)
+        if every_ms <= 0:
+            raise ValueError("everyMs must be > 0")
+        minutes = max(1, every_ms // 60000)
+        display = f"every {minutes}m"
+        return {"kind": "interval", "minutes": minutes, "display": display}, display
+    if kind == "at":
+        at = str(schedule.get("at") or "").strip()
+        if not at:
+            raise ValueError("at timestamp required")
+        display = f"once at {at}"
+        return {"kind": "once", "run_at": at, "display": display}, display
+    raise ValueError(f"unsupported schedule.kind {kind}")
+
+
+def _translate_delivery(delivery):
+    if not isinstance(delivery, dict):
+        return "origin", ""
+    mode = str(delivery.get("mode") or "").strip().lower()
+    channel = str(delivery.get("channel") or "").strip()
+    to = str(delivery.get("to") or "").strip()
+    if mode in ("", "announce"):
+        if not channel or channel == "last":
+            return "origin", ""
+        if to:
+            return f"{channel}:{to}", ""
+        return channel, ""
+    if mode == "none":
+        return "local", ""
+    if mode == "webhook":
+        if not to:
+            raise ValueError("webhook delivery.to required")
+        parsed = urlparse(to)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("webhook delivery.to must be http(s)")
+        return "local", to
+    raise ValueError(f"unsupported delivery.mode {mode}")
+
+
+def _extract_prompt(payload):
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be an object")
+    kind = str(payload.get("kind") or "").strip()
+    model = payload.get("model")
+    if kind == "agentTurn":
+        message = str(payload.get("message") or "").strip()
+        if not message:
+            raise ValueError("agentTurn message required")
+        return message, model
+    if kind == "systemEvent":
+        text = str(payload.get("text") or "").strip()
+        if not text:
+            raise ValueError("systemEvent text required")
+        return "System event (from ClawManager scheduled task):\n" + text, model
+    raise ValueError(f"unsupported payload.kind {kind}")
+
+
+def apply_scheduled_tasks(hermes_home):
+    payload = read_priority_json("scheduled_tasks")
+    record = {
+        "source_env": payload["source_env"],
+        "raw_sha256": payload["raw_sha256"],
+        "error": payload["error"],
+        "job_count": 0,
+        "skipped": not bool(payload["source_env"]),
+        "ignored_fields": ["wakeMode", "sessionTarget"],
+        "updated_at": utc_now(),
+    }
+    if payload["error"]:
+        persist_bootstrap_payload(hermes_home, "scheduled-tasks", record)
+        return record
+    if not payload["source_env"]:
+        return record
+
+    parsed = payload["parsed"]
+    items = []
+    if isinstance(parsed, dict):
+        raw_items = parsed.get("items")
+        if isinstance(raw_items, list):
+            items = raw_items
+
+    cron_dir = Path(hermes_home) / "cron"
+    jobs_path = cron_dir / "jobs.json"
+    webhook_dir = cron_dir / "webhooks"
+    hash_path = cron_dir / "clawmanager-scheduled-tasks.sha256"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+
+    existing_jobs = []
+    if jobs_path.exists():
+        try:
+            existing_data = json.loads(jobs_path.read_text(encoding="utf-8") or "{}")
+            if isinstance(existing_data, dict) and isinstance(existing_data.get("jobs"), list):
+                existing_jobs = existing_data["jobs"]
+            elif isinstance(existing_data, list):
+                existing_jobs = existing_data
+        except Exception as exc:
+            record["error"] = f"parse existing hermes cron jobs: {exc}"
+            persist_bootstrap_payload(hermes_home, "scheduled-tasks", record)
+            return record
+
+    managed_item_count = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        resource_type = str(item.get("type") or "").strip().lower()
+        if resource_type and resource_type != "scheduled_task":
+            continue
+        managed_item_count += 1
+    existing_managed_count = sum(
+        1
+        for job in existing_jobs
+        if isinstance(job, dict) and str(job.get("id") or "").startswith(MANAGED_JOB_PREFIX)
+    )
+    if (
+        hash_path.exists()
+        and hash_path.read_text(encoding="utf-8").strip() == payload["raw_sha256"]
+        and existing_managed_count == managed_item_count
+    ):
+        record["job_count"] = managed_item_count
+        record["skipped"] = True
+        persist_bootstrap_payload(hermes_home, "scheduled-tasks", record)
+        return record
+
+    existing_by_id = {
+        str(job.get("id")): job
+        for job in existing_jobs
+        if isinstance(job, dict) and job.get("id")
+    }
+    kept = [
+        job
+        for job in existing_jobs
+        if isinstance(job, dict) and not str(job.get("id") or "").startswith(MANAGED_JOB_PREFIX)
+    ]
+
+    managed = []
+    try:
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            resource_type = str(item.get("type") or "").strip().lower()
+            if resource_type and resource_type != "scheduled_task":
+                continue
+            content = item.get("content")
+            if isinstance(content, str):
+                content = json.loads(content)
+            if not isinstance(content, dict):
+                raise ValueError(f"invalid content for scheduled task id={item.get('id')}")
+            cfg = content.get("config")
+            if not isinstance(cfg, dict):
+                raise ValueError(f"missing config for scheduled task id={item.get('id')}")
+            prompt, model = _extract_prompt(cfg.get("payload") or {})
+            schedule, display = _translate_schedule(cfg.get("schedule") or {})
+            deliver, webhook_url = _translate_delivery(cfg.get("delivery") or {})
+            job_id = f"{MANAGED_JOB_PREFIX}{item.get('id')}"
+            if webhook_url:
+                prompt = (
+                    prompt
+                    + "\n\n[ClawManager delivery.webhook]\n"
+                    + "After you finish, POST your complete final answer as JSON {\"text\": \"...\"} to "
+                    + webhook_url
+                    + " using an available HTTP tool. Treat webhook delivery as required."
+                )
+                webhook_dir.mkdir(parents=True, exist_ok=True)
+                (webhook_dir / f"{job_id}.url").write_text(webhook_url + "\n", encoding="utf-8")
+            name = str(cfg.get("name") or item.get("name") or item.get("key") or job_id).strip()
+            enabled = cfg.get("enabled")
+            if enabled is None:
+                enabled = True
+            enabled = bool(enabled)
+            now = utc_now()
+            job = {
+                "id": job_id,
+                "name": name,
+                "prompt": prompt,
+                "schedule": schedule,
+                "skills": [],
+                "skill": None,
+                "deliver": deliver,
+                "repeat": {"times": 1 if cfg.get("deleteAfterRun") else None, "completed": 0},
+                "state": "scheduled" if enabled else "paused",
+                "enabled": enabled,
+                "next_run_at": schedule.get("run_at") if schedule.get("kind") == "once" else now,
+                "last_run_at": None,
+                "last_status": None,
+                "created_at": now,
+                "model": model,
+                "provider": None,
+                "script": None,
+                "schedule_display": display,
+            }
+            prev = existing_by_id.get(job_id)
+            if isinstance(prev, dict):
+                if prev.get("created_at"):
+                    job["created_at"] = prev.get("created_at")
+                job["last_run_at"] = prev.get("last_run_at")
+                job["last_status"] = prev.get("last_status")
+                prev_repeat = prev.get("repeat")
+                if isinstance(prev_repeat, dict) and "completed" in prev_repeat:
+                    job["repeat"]["completed"] = prev_repeat.get("completed")
+            managed.append(job)
+    except Exception as exc:
+        record["error"] = str(exc)
+        persist_bootstrap_payload(hermes_home, "scheduled-tasks", record)
+        return record
+
+    kept.extend(managed)
+    record["job_count"] = len(managed)
+    record["skipped"] = False
+    write_json_secure(jobs_path, {"jobs": kept, "updated_at": utc_now()})
+    hash_path.write_text(payload["raw_sha256"] + "\n", encoding="utf-8")
+    persist_bootstrap_payload(hermes_home, "scheduled-tasks", record)
+    return record
+
+
 def write_applied_state(hermes_home, state):
     state["updated_at"] = utc_now()
     write_json_secure(bootstrap_dir(hermes_home) / "applied-state.json", state)
@@ -1703,6 +1942,7 @@ messaging_env_updates, messaging_sources, configured_platforms, gateway_written,
 )
 redis_team_record = apply_redis_team_config(hermes_home, data)
 manifest_record = apply_bootstrap_manifest(hermes_home)
+scheduled_tasks_record = apply_scheduled_tasks(hermes_home)
 write_applied_state(
     hermes_home,
     {
@@ -1727,6 +1967,14 @@ write_applied_state(
             "source_env": manifest_record.get("source_env", ""),
             "raw_sha256": manifest_record.get("raw_sha256", ""),
             "error": manifest_record.get("error", ""),
+        },
+        "scheduled_tasks": {
+            "source_env": scheduled_tasks_record.get("source_env", ""),
+            "raw_sha256": scheduled_tasks_record.get("raw_sha256", ""),
+            "job_count": scheduled_tasks_record.get("job_count", 0),
+            "skipped": scheduled_tasks_record.get("skipped", False),
+            "ignored_fields": scheduled_tasks_record.get("ignored_fields", []),
+            "error": scheduled_tasks_record.get("error", ""),
         },
         "redis_team": {
             "enabled": redis_team_record.get("enabled", False),

--- a/hermes/rootfs/usr/local/bin/start-hermes-dashboard-gateway
+++ b/hermes/rootfs/usr/local/bin/start-hermes-dashboard-gateway
@@ -59,6 +59,45 @@ falsey() {
     esac
 }
 
+# Newer Hermes ignores --insecure for non-loopback binds; require a dashboard
+# auth provider (basic auth) before binding HOST=0.0.0.0.
+ensure_dashboard_basic_auth() {
+    if [ -n "${HERMES_DASHBOARD_BASIC_AUTH_USERNAME:-}" ] && {
+        [ -n "${HERMES_DASHBOARD_BASIC_AUTH_PASSWORD:-}" ] ||
+            [ -n "${HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH:-}" ]
+    }; then
+        return 0
+    fi
+
+    export HERMES_DASHBOARD_BASIC_AUTH_USERNAME="${HERMES_DASHBOARD_BASIC_AUTH_USERNAME:-clawmanager}"
+
+    if [ -z "${HERMES_DASHBOARD_BASIC_AUTH_PASSWORD:-}" ] && [ -z "${HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH:-}" ]; then
+        if [ -n "${CLAWMANAGER_DASHBOARD_BASIC_AUTH_PASSWORD:-}" ]; then
+            export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="${CLAWMANAGER_DASHBOARD_BASIC_AUTH_PASSWORD}"
+        elif [ -n "${CLAWMANAGER_INSTANCE_ACCESS_TOKEN:-}" ]; then
+            export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="${CLAWMANAGER_INSTANCE_ACCESS_TOKEN}"
+        elif [ -n "${CLAWMANAGER_INSTANCE_TOKEN:-}" ]; then
+            # ClawManager BuildGatewayEnv currently ships this key for AccessToken.
+            export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="${CLAWMANAGER_INSTANCE_TOKEN}"
+        elif [ -n "${CLAWMANAGER_GATEWAY_TOKEN:-}" ]; then
+            export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="${CLAWMANAGER_GATEWAY_TOKEN}"
+        else
+            auth_file="${HERMES_HOME}/.clawmanager-dashboard-basic-auth"
+            if [ -f "${auth_file}" ]; then
+                export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="$(tr -d '\r\n' <"${auth_file}")"
+            else
+                if command -v openssl >/dev/null 2>&1; then
+                    generated_password="$(openssl rand -hex 16)"
+                else
+                    generated_password="$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+                fi
+                umask 077
+                printf '%s' "${generated_password}" >"${auth_file}"
+                export HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="${generated_password}"
+            fi
+        fi
+    fi
+}
 
 should_start_team_gateway() {
     truthy "${CLAWMANAGER_TEAM_ENABLED:-}" || return 1
@@ -139,11 +178,12 @@ if should_start_team_gateway; then
     team_gateway_pid="$!"
 fi
 
+ensure_dashboard_basic_auth
+
 hermes dashboard \
     --host "${host}" \
     --port "${port}" \
     --no-open \
-    --insecure \
     --skip-build &
 dashboard_pid="$!"
 

--- a/hermes/rootfs/usr/local/bin/start-hermes-gateway
+++ b/hermes/rootfs/usr/local/bin/start-hermes-gateway
@@ -67,6 +67,52 @@ has_gateway_env_file() {
     [ -f "${env_file}" ] && grep -Eq '^(TELEGRAM_BOT_TOKEN|DISCORD_BOT_TOKEN|SLACK_BOT_TOKEN|WHATSAPP_ENABLED|SIGNAL_HTTP_URL|SIGNAL_ACCOUNT|MATTERMOST_TOKEN|MATRIX_ACCESS_TOKEN|MATRIX_PASSWORD|DINGTALK_CLIENT_ID|FEISHU_APP_ID|WECOM_BOT_ID|WECOM_CALLBACK_CORP_ID|WEIXIN_TOKEN|QQBOT_APP_ID|BLUEBUBBLES_SERVER_URL|YUANBAO_APP_ID|API_SERVER_ENABLED|WEBHOOK_ENABLED)=' "${env_file}"
 }
 
+has_scheduled_tasks_env() {
+    for name in \
+        CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON \
+        CLAWMANAGER_RUNTIME_SCHEDULED_TASKS_JSON \
+        CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON
+    do
+        raw="${!name:-}"
+        if [ -z "${raw}" ]; then
+            continue
+        fi
+        # Non-empty managed payload includes at least one object in items[].
+        if printf '%s' "${raw}" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"scheduled_task"'; then
+            return 0
+        fi
+        if printf '%s' "${raw}" | grep -Eq '"items"[[:space:]]*:[[:space:]]*\[[[:space:]]*\{'; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_hermes_pro_desktop() {
+    runtime="$(printf '%s' "${CLAWMANAGER_RUNTIME_TYPE:-}" | tr '[:upper:]' '[:lower:]')"
+    agent_rt="$(printf '%s' "${CLAWMANAGER_AGENT_RUNTIME_TYPE:-}" | tr '[:upper:]' '[:lower:]')"
+    case "${runtime}" in
+        desktop) return 0 ;;
+    esac
+    # Dedicated Pro containers set agent runtime to hermes without Runtime Pod tokens.
+    if [ "${agent_rt}" = "hermes" ] &&
+        [ -z "${RUNTIME_AGENT_CONTROL_TOKEN:-}" ] &&
+        [ -z "${RUNTIME_AGENT_REPORT_TOKEN:-}" ]; then
+        return 0
+    fi
+    return 1
+}
+
+ensure_default_gateway_profile() {
+    if hermes profile list 2>/dev/null | grep -Eq '(^|[[:space:]◆*])default([[:space:]]|$)'; then
+        return 0
+    fi
+    echo "Creating Hermes gateway profile 'default'"
+    if ! hermes profile create default --description "ClawManager default gateway profile" 2>/tmp/hermes-profile-create.log; then
+        echo "hermes profile create default failed (continuing): $(tr '\n' ' ' </tmp/hermes-profile-create.log 2>/dev/null || true)"
+    fi
+}
+
 should_start_gateway=false
 case "${gateway_mode}" in
     1|true|yes|y|on|enabled)
@@ -76,16 +122,19 @@ case "${gateway_mode}" in
         should_start_gateway=false
         ;;
     *)
-        if has_runtime_channel_env || has_redis_team_env || has_gateway_env_file; then
+        if has_runtime_channel_env || has_redis_team_env || has_gateway_env_file ||
+            has_scheduled_tasks_env || is_hermes_pro_desktop; then
             should_start_gateway=true
         fi
         ;;
 esac
 
 if [ "${should_start_gateway}" != "true" ]; then
-    echo "Hermes gateway disabled; no channel configuration detected"
+    echo "Hermes gateway disabled; no channel/scheduled-task/Pro configuration detected"
     exec sleep infinity
 fi
+
+ensure_default_gateway_profile || true
 
 if [ "$(id -u)" = "0" ]; then
     if id abc >/dev/null 2>&1; then
@@ -98,7 +147,9 @@ if [ "$(id -u)" = "0" ]; then
         fi
     fi
     if command -v s6-setuidgid >/dev/null 2>&1 && id abc >/dev/null 2>&1; then
-        exec s6-setuidgid abc /bin/bash -lc 'cd /config && exec hermes gateway'
+        # Must use `gateway run`; bare `hermes gateway` exits with a misleading
+        # "no such gateway 'default'" error even when the profile exists.
+        exec s6-setuidgid abc /bin/bash -lc 'cd /config && exec hermes gateway run --accept-hooks --no-supervise'
     fi
 fi
 

--- a/hermes/rootfs_scripts_test.go
+++ b/hermes/rootfs_scripts_test.go
@@ -27,6 +27,37 @@ func TestDashboardGatewayScriptStartsRedisTeamConsumerWhenAutorunEnabled(t *test
 	}
 }
 
+func TestDashboardGatewayScriptEnsuresBasicAuthBeforeBind(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("rootfs", "usr", "local", "bin", "start-hermes-dashboard-gateway"))
+	if err != nil {
+		t.Fatalf("read start-hermes-dashboard-gateway: %v", err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		"ensure_dashboard_basic_auth",
+		"HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+		"HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+		"CLAWMANAGER_DASHBOARD_BASIC_AUTH_PASSWORD",
+		"CLAWMANAGER_INSTANCE_ACCESS_TOKEN",
+		"CLAWMANAGER_INSTANCE_TOKEN",
+		"CLAWMANAGER_GATEWAY_TOKEN",
+		".clawmanager-dashboard-basic-auth",
+		`--host "${host}"`,
+		`--port "${port}"`,
+		"--no-open",
+		"--skip-build",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("start-hermes-dashboard-gateway missing %q", want)
+		}
+	}
+	if idx := strings.Index(script, "hermes dashboard"); idx < 0 {
+		t.Fatal("start-hermes-dashboard-gateway missing hermes dashboard launch")
+	} else if strings.Contains(script[idx:], "--insecure") {
+		t.Fatal("hermes dashboard launch must not pass --insecure; basic auth is required for non-loopback binds")
+	}
+}
+
 func TestDashboardGatewayScriptStartsClawManagerInstanceAgent(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("rootfs", "usr", "local", "bin", "start-hermes-dashboard-gateway"))
 	if err != nil {
@@ -66,6 +97,51 @@ func TestApplyRuntimeConfigAliasesClawManagerProviderAsCustom(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("hermes-apply-runtime-config missing %q", want)
 		}
+	}
+}
+
+func TestApplyRuntimeConfigAppliesScheduledTasks(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("rootfs", "usr", "local", "bin", "hermes-apply-runtime-config"))
+	if err != nil {
+		t.Fatalf("read hermes-apply-runtime-config: %v", err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		`"scheduled_tasks": (`,
+		`CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON`,
+		`def apply_scheduled_tasks(hermes_home):`,
+		`jobs_path = cron_dir / "jobs.json"`,
+		`scheduled_tasks_record = apply_scheduled_tasks(hermes_home)`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("hermes-apply-runtime-config missing %q", want)
+		}
+	}
+}
+
+func TestStartHermesGatewayEnsuresDefaultProfileAndProStart(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("rootfs", "usr", "local", "bin", "start-hermes-gateway"))
+	if err != nil {
+		t.Fatalf("read start-hermes-gateway: %v", err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		"ensure_default_gateway_profile",
+		"hermes profile create default",
+		"has_scheduled_tasks_env",
+		"is_hermes_pro_desktop",
+		"CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON",
+		"hermes gateway run --accept-hooks --no-supervise",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("start-hermes-gateway missing %q", want)
+		}
+	}
+	if strings.Contains(script, "exec hermes gateway'") || strings.Contains(script, "exec hermes gateway\"") {
+		t.Fatal("start-hermes-gateway must not exec bare `hermes gateway` without run")
+	}
+	if strings.Contains(script, "&& exec hermes gateway\n") || strings.Contains(script, "&& exec hermes gateway'") {
+		t.Fatal("start-hermes-gateway must not exec bare `hermes gateway` without run")
 	}
 }
 

--- a/openclaw/Dockerfile.agent-overlay.nosyntax
+++ b/openclaw/Dockerfile.agent-overlay.nosyntax
@@ -13,7 +13,7 @@
 
 ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/openclaw-lite:latest
 
-FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS clawmanager-agent-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS clawmanager-agent-builder
 
 WORKDIR /src/clawmanager-agent
 

--- a/openclaw/Dockerfile.pro-overlay.nosyntax
+++ b/openclaw/Dockerfile.pro-overlay.nosyntax
@@ -1,0 +1,38 @@
+# Local smoke: published OpenClaw Pro + rebuilt openclaw-agent + clawmanager-agent.
+#
+#   docker build -f openclaw/Dockerfile.pro-overlay.nosyntax \
+#     --build-arg BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/openclaw:latest \
+#     -t openclaw:local .
+
+ARG BASE_IMAGE=ghcr.io/yuan-lab-llm/agentsruntime/openclaw:latest
+
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS agent-builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG AGENT_VERSION=dev
+
+WORKDIR /src/clawmanager-agent
+COPY clawmanager-agent ./
+RUN go mod download
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+      go build -trimpath -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+      -o /out/clawmanager-agent ./cmd/clawmanager-agent
+
+WORKDIR /src/openclaw
+COPY openclaw/go.mod openclaw/go.sum ./
+RUN go mod download
+COPY openclaw/cmd ./cmd
+COPY openclaw/internal ./internal
+RUN set -eux; \
+    arch="${TARGETARCH:-amd64}"; \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${arch}" \
+      go build -trimpath -ldflags="-s -w" \
+      -o /out/openclaw-agent ./cmd/openclaw-agent
+
+FROM ${BASE_IMAGE}
+COPY --from=agent-builder /out/clawmanager-agent /usr/local/bin/clawmanager-agent
+COPY --from=agent-builder /out/openclaw-agent /usr/local/bin/openclaw-agent
+RUN chmod 755 /usr/local/bin/clawmanager-agent /usr/local/bin/openclaw-agent

--- a/openclaw/internal/configmanager/normalizer.go
+++ b/openclaw/internal/configmanager/normalizer.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	appconfig "github.com/iamlovingit/clawmanager-openclaw-image/internal/config"
+	"github.com/iamlovingit/clawmanager-openclaw-image/internal/scheduledtasks"
 )
 
 const autoProviderName = "auto"
@@ -27,7 +29,17 @@ func (m *Manager) NormalizeActiveConfig() error {
 			return err
 		}
 	}
-	return normalizePluginInstallRegistry(m.cfg)
+	if err := normalizePluginInstallRegistry(m.cfg); err != nil {
+		return err
+	}
+	openclawHome := filepath.Dir(m.cfg.OpenClawConfigPath)
+	result := scheduledtasks.ApplyOpenClawFromEnv(openclawHome, os.Getenv)
+	if result.Error != "" {
+		log.Printf("configmanager: apply openclaw scheduled tasks failed (continuing): source_env=%s error=%s", result.SourceEnv, result.Error)
+	} else if result.Skipped {
+		log.Printf("configmanager: openclaw scheduled tasks apply skipped source_env=%s", result.SourceEnv)
+	}
+	return nil
 }
 
 func normalizeConfigFile(path string, cfg appconfig.Config) ([]byte, bool, error) {

--- a/openclaw/internal/scheduledtasks/apply.go
+++ b/openclaw/internal/scheduledtasks/apply.go
@@ -1,0 +1,312 @@
+package scheduledtasks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ManagedJobIDPrefix = "cm-st-"
+	EnvHermes          = "CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON"
+	EnvRuntime         = "CLAWMANAGER_RUNTIME_SCHEDULED_TASKS_JSON"
+	EnvOpenClaw        = "CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON"
+)
+
+type PayloadEnvelope struct {
+	SchemaVersion int          `json:"schemaVersion"`
+	Items         []PayloadItem `json:"items"`
+}
+
+type PayloadItem struct {
+	ID      int             `json:"id"`
+	Type    string          `json:"type"`
+	Key     string          `json:"key"`
+	Name    string          `json:"name"`
+	Version int             `json:"version"`
+	Tags    []string        `json:"tags"`
+	Content json.RawMessage `json:"content"`
+}
+
+type ResourceContent struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	Kind          string          `json:"kind"`
+	Format        string          `json:"format"`
+	Config        json.RawMessage `json:"config"`
+}
+
+type CronStoreFile struct {
+	Version int       `json:"version"`
+	Jobs    []CronJob `json:"jobs"`
+}
+
+type CronJob struct {
+	ID            string          `json:"id"`
+	AgentID       string          `json:"agentId,omitempty"`
+	SessionKey    string          `json:"sessionKey,omitempty"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description,omitempty"`
+	Enabled       bool            `json:"enabled"`
+	DeleteAfterRun bool           `json:"deleteAfterRun,omitempty"`
+	CreatedAtMs   int64           `json:"createdAtMs"`
+	UpdatedAtMs   int64           `json:"updatedAtMs"`
+	Schedule      json.RawMessage `json:"schedule"`
+	SessionTarget string          `json:"sessionTarget"`
+	WakeMode      string          `json:"wakeMode"`
+	Payload       json.RawMessage `json:"payload"`
+	Delivery      json.RawMessage `json:"delivery,omitempty"`
+	State         map[string]any  `json:"state"`
+}
+
+type ApplyResult struct {
+	SourceEnv     string   `json:"source_env"`
+	RawSHA256     string   `json:"raw_sha256"`
+	JobCount      int      `json:"job_count"`
+	Skipped       bool     `json:"skipped"`
+	StorePath     string   `json:"store_path"`
+	Error         string   `json:"error,omitempty"`
+	IgnoredFields []string `json:"ignored_fields,omitempty"`
+}
+
+type jobConfig struct {
+	Name           string          `json:"name"`
+	Description    string          `json:"description,omitempty"`
+	Enabled        *bool           `json:"enabled,omitempty"`
+	DeleteAfterRun *bool           `json:"deleteAfterRun,omitempty"`
+	AgentID        string          `json:"agentId,omitempty"`
+	SessionKey     string          `json:"sessionKey,omitempty"`
+	Schedule       json.RawMessage `json:"schedule"`
+	SessionTarget  string          `json:"sessionTarget"`
+	WakeMode       string          `json:"wakeMode"`
+	Payload        json.RawMessage `json:"payload"`
+	Delivery       json.RawMessage `json:"delivery,omitempty"`
+}
+
+// ReadScheduledTasksEnv returns the first non-empty scheduled tasks payload and its env name.
+func ReadScheduledTasksEnv(getenv func(string) string) (envName string, raw string) {
+	for _, key := range []string{EnvHermes, EnvRuntime, EnvOpenClaw} {
+		value := strings.TrimSpace(getenv(key))
+		if value != "" {
+			return key, value
+		}
+	}
+	return "", ""
+}
+
+// ApplyOpenClawFromEnv merges ClawManager managed cron jobs into an OpenClaw cron store.
+func ApplyOpenClawFromEnv(openclawHome string, getenv func(string) string) ApplyResult {
+	return ApplyFromEnv(OpenClawCronStorePath(openclawHome), getenv)
+}
+
+// ApplyFromEnv merges ClawManager managed cron jobs into storePath (OpenClaw schema).
+func ApplyFromEnv(storePath string, getenv func(string) string) ApplyResult {
+	result := ApplyResult{StorePath: storePath}
+	envName, raw := ReadScheduledTasksEnv(getenv)
+	if envName == "" {
+		result.Skipped = true
+		return result
+	}
+	result.SourceEnv = envName
+	sum := sha256.Sum256([]byte(raw))
+	result.RawSHA256 = hex.EncodeToString(sum[:])
+
+	jobs, err := jobsFromPayload(raw)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.JobCount = len(jobs)
+
+	existing, err := loadStore(storePath)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if openClawManagedSetMatches(existing.Jobs, jobs, result.RawSHA256) {
+		result.Skipped = true
+		return result
+	}
+
+	if err := upsertManagedJobs(storePath, existing, jobs, result.RawSHA256); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	return result
+}
+
+func openClawManagedSetMatches(existingJobs, managed []CronJob, payloadHash string) bool {
+	existingManaged := map[string]string{}
+	for _, job := range existingJobs {
+		if !strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+			continue
+		}
+		hash := ""
+		if job.State != nil {
+			if value, ok := job.State["clawmanagerPayloadSHA256"].(string); ok {
+				hash = value
+			}
+		}
+		existingManaged[job.ID] = hash
+	}
+	if len(existingManaged) != len(managed) {
+		return false
+	}
+	for _, job := range managed {
+		hash, ok := existingManaged[job.ID]
+		if !ok || hash != payloadHash {
+			return false
+		}
+	}
+	return true
+}
+
+func jobsFromPayload(raw string) ([]CronJob, error) {
+	var payload PayloadEnvelope
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("parse scheduled tasks payload: %w", err)
+	}
+	now := time.Now().UTC().UnixMilli()
+	jobs := make([]CronJob, 0, len(payload.Items))
+	for _, item := range payload.Items {
+		if strings.TrimSpace(strings.ToLower(item.Type)) != "" &&
+			strings.TrimSpace(strings.ToLower(item.Type)) != "scheduled_task" {
+			continue
+		}
+		var content ResourceContent
+		if err := json.Unmarshal(item.Content, &content); err != nil {
+			return nil, fmt.Errorf("parse scheduled task content for id=%d: %w", item.ID, err)
+		}
+		var cfg jobConfig
+		if err := json.Unmarshal(content.Config, &cfg); err != nil {
+			return nil, fmt.Errorf("parse scheduled task config for id=%d: %w", item.ID, err)
+		}
+		name := strings.TrimSpace(cfg.Name)
+		if name == "" {
+			name = strings.TrimSpace(item.Name)
+		}
+		if name == "" {
+			name = item.Key
+		}
+		enabled := true
+		if cfg.Enabled != nil {
+			enabled = *cfg.Enabled
+		}
+		deleteAfterRun := false
+		if cfg.DeleteAfterRun != nil {
+			deleteAfterRun = *cfg.DeleteAfterRun
+		}
+		jobID := ManagedJobIDPrefix + strconv.Itoa(item.ID)
+		jobs = append(jobs, CronJob{
+			ID:             jobID,
+			AgentID:        strings.TrimSpace(cfg.AgentID),
+			SessionKey:     strings.TrimSpace(cfg.SessionKey),
+			Name:           name,
+			Description:    cfg.Description,
+			Enabled:        enabled,
+			DeleteAfterRun: deleteAfterRun,
+			CreatedAtMs:    now,
+			UpdatedAtMs:    now,
+			Schedule:       cfg.Schedule,
+			SessionTarget:  strings.TrimSpace(cfg.SessionTarget),
+			WakeMode:       strings.TrimSpace(cfg.WakeMode),
+			Payload:        cfg.Payload,
+			Delivery:       cfg.Delivery,
+			State:          map[string]any{},
+		})
+	}
+	return jobs, nil
+}
+
+func upsertManagedJobs(storePath string, existing CronStoreFile, managed []CronJob, payloadHash string) error {
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o750); err != nil {
+		return fmt.Errorf("create cron store dir: %w", err)
+	}
+
+	kept := make([]CronJob, 0, len(existing.Jobs))
+	for _, job := range existing.Jobs {
+		if strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+			continue
+		}
+		kept = append(kept, job)
+	}
+
+	now := time.Now().UTC().UnixMilli()
+	existingByID := map[string]CronJob{}
+	for _, job := range existing.Jobs {
+		existingByID[job.ID] = job
+	}
+	for _, job := range managed {
+		if prev, ok := existingByID[job.ID]; ok {
+			job.CreatedAtMs = prev.CreatedAtMs
+			if prev.State != nil {
+				job.State = prev.State
+			}
+		} else {
+			job.CreatedAtMs = now
+		}
+		job.UpdatedAtMs = now
+		if job.State == nil {
+			job.State = map[string]any{}
+		}
+		job.State["clawmanagerPayloadSHA256"] = payloadHash
+		kept = append(kept, job)
+	}
+
+	next := CronStoreFile{Version: 1, Jobs: kept}
+	return saveStore(storePath, next)
+}
+
+func loadStore(path string) (CronStoreFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CronStoreFile{Version: 1, Jobs: []CronJob{}}, nil
+		}
+		return CronStoreFile{}, fmt.Errorf("read cron store: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return CronStoreFile{Version: 1, Jobs: []CronJob{}}, nil
+	}
+	var store CronStoreFile
+	if err := json.Unmarshal(data, &store); err != nil {
+		return CronStoreFile{}, fmt.Errorf("parse cron store: %w", err)
+	}
+	if store.Version == 0 {
+		store.Version = 1
+	}
+	if store.Jobs == nil {
+		store.Jobs = []CronJob{}
+	}
+	return store, nil
+}
+
+func saveStore(path string, store CronStoreFile) error {
+	raw, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cron store: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(raw, '\n'), 0o640); err != nil {
+		return fmt.Errorf("write cron store temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace cron store: %w", err)
+	}
+	return nil
+}
+
+// OpenClawCronStorePath returns the OpenClaw cron jobs.json under openclawHome.
+func OpenClawCronStorePath(openclawHome string) string {
+	return filepath.Join(openclawHome, "cron", "jobs.json")
+}
+
+// HermesCronStorePath returns the Hermes cron jobs.json under hermesHome.
+func HermesCronStorePath(hermesHome string) string {
+	return filepath.Join(hermesHome, "cron", "jobs.json")
+}

--- a/openclaw/internal/scheduledtasks/apply_test.go
+++ b/openclaw/internal/scheduledtasks/apply_test.go
@@ -1,0 +1,150 @@
+package scheduledtasks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyOpenClawFromEnvUpsertsManagedJobs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	openclawHome := filepath.Join(dir, ".openclaw")
+
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   7,
+				"type": "scheduled_task",
+				"key":  "daily",
+				"name": "Daily",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "daily",
+						"enabled":       true,
+						"schedule":      map[string]any{"kind": "cron", "expr": "0 9 * * *"},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "brief"},
+						"delivery":      map[string]any{"mode": "announce", "channel": "last"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvOpenClaw: string(raw)}
+	result := ApplyOpenClawFromEnv(openclawHome, func(key string) string { return env[key] })
+	if result.Error != "" {
+		t.Fatalf("apply error: %s", result.Error)
+	}
+	if result.JobCount != 1 {
+		t.Fatalf("job count = %d", result.JobCount)
+	}
+	store, err := loadStore(OpenClawCronStorePath(openclawHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Jobs) != 1 || store.Jobs[0].ID != "cm-st-7" {
+		t.Fatalf("unexpected jobs: %+v", store.Jobs)
+	}
+	if !strings.Contains(string(store.Jobs[0].Delivery), `"mode"`) ||
+		!strings.Contains(string(store.Jobs[0].Delivery), `announce`) {
+		t.Fatalf("delivery not preserved: %s", string(store.Jobs[0].Delivery))
+	}
+
+	second := ApplyOpenClawFromEnv(openclawHome, func(key string) string { return env[key] })
+	if second.Error != "" {
+		t.Fatalf("second apply error: %s", second.Error)
+	}
+	if !second.Skipped {
+		t.Fatal("expected second identical apply to skip")
+	}
+}
+
+func TestApplyHermesFromEnvTranslatesWebhookAndAnnounce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	hermesHome := filepath.Join(dir, ".hermes")
+
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"items": []map[string]any{
+			{
+				"id":   9,
+				"type": "scheduled_task",
+				"key":  "hook",
+				"name": "Hook",
+				"content": map[string]any{
+					"schemaVersion": 1,
+					"kind":          "scheduled_task",
+					"format":        "task/openclaw-cron@v1",
+					"config": map[string]any{
+						"name":          "hook",
+						"schedule":      map[string]any{"kind": "every", "everyMs": 120000},
+						"sessionTarget": "isolated",
+						"wakeMode":      "now",
+						"payload":       map[string]any{"kind": "agentTurn", "message": "ping"},
+						"delivery":      map[string]any{"mode": "webhook", "to": "https://example.com/h"},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvHermes: string(raw)}
+	result := ApplyHermesFromEnv(hermesHome, func(key string) string { return env[key] })
+	if result.Error != "" {
+		t.Fatalf("apply error: %s", result.Error)
+	}
+	file, err := loadHermesJobs(HermesCronStorePath(hermesHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(file.Jobs) != 1 {
+		t.Fatalf("jobs=%d", len(file.Jobs))
+	}
+	job := file.Jobs[0]
+	if job.ID != "cm-st-9" {
+		t.Fatalf("id=%s", job.ID)
+	}
+	if job.Deliver != "local" {
+		t.Fatalf("deliver=%s", job.Deliver)
+	}
+	if job.Schedule["kind"] != "interval" {
+		t.Fatalf("schedule=%v", job.Schedule)
+	}
+	if !strings.Contains(job.Prompt, "https://example.com/h") {
+		t.Fatalf("webhook instruction missing: %s", job.Prompt)
+	}
+	webhookFile := filepath.Join(hermesHome, "cron", "webhooks", "cm-st-9.url")
+	data, err := os.ReadFile(webhookFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "https://example.com/h" {
+		t.Fatalf("webhook file=%q", string(data))
+	}
+	if len(result.IgnoredFields) == 0 {
+		t.Fatal("expected ignored_fields for hermes translation")
+	}
+	second := ApplyHermesFromEnv(hermesHome, func(key string) string { return env[key] })
+	if second.Error != "" {
+		t.Fatalf("second hermes apply error: %s", second.Error)
+	}
+	if !second.Skipped {
+		t.Fatal("expected second identical hermes apply to skip")
+	}
+}

--- a/openclaw/internal/scheduledtasks/hermes.go
+++ b/openclaw/internal/scheduledtasks/hermes.go
@@ -1,0 +1,396 @@
+package scheduledtasks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type HermesJobsFile struct {
+	Jobs      []HermesJob `json:"jobs"`
+	UpdatedAt string      `json:"updated_at,omitempty"`
+}
+
+type HermesJob struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Prompt      string         `json:"prompt"`
+	Schedule    map[string]any `json:"schedule"`
+	Skills      []string       `json:"skills"`
+	Skill       any            `json:"skill"`
+	Deliver     string         `json:"deliver"`
+	Repeat      map[string]any `json:"repeat"`
+	State       string         `json:"state"`
+	Enabled     bool           `json:"enabled"`
+	NextRunAt   *string        `json:"next_run_at"`
+	LastRunAt   any            `json:"last_run_at"`
+	LastStatus  any            `json:"last_status"`
+	CreatedAt   string         `json:"created_at"`
+	Model       any            `json:"model"`
+	Provider    any            `json:"provider"`
+	Script      any            `json:"script"`
+	ScheduleDisplay string     `json:"schedule_display,omitempty"`
+}
+
+// ApplyHermesFromEnv translates OpenClaw-benchmark scheduled tasks into Hermes
+// native cron jobs and upserts managed entries into hermes jobs.json.
+func ApplyHermesFromEnv(hermesHome string, getenv func(string) string) ApplyResult {
+	storePath := HermesCronStorePath(hermesHome)
+	result := ApplyResult{
+		StorePath:     storePath,
+		IgnoredFields: []string{"wakeMode", "sessionTarget"},
+	}
+	envName, raw := ReadScheduledTasksEnv(getenv)
+	if envName == "" {
+		result.Skipped = true
+		return result
+	}
+	result.SourceEnv = envName
+	sum := sha256Sum(raw)
+	result.RawSHA256 = sum
+
+	hashPath := filepath.Join(hermesHome, "cron", "clawmanager-scheduled-tasks.sha256")
+	if previous, err := os.ReadFile(hashPath); err == nil && strings.TrimSpace(string(previous)) == sum {
+		existing, loadErr := loadHermesJobs(storePath)
+		if loadErr == nil {
+			managedCount := 0
+			for _, job := range existing.Jobs {
+				if strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+					managedCount++
+				}
+			}
+			openClawJobs, parseErr := jobsFromPayload(raw)
+			if parseErr == nil && managedCount == len(openClawJobs) {
+				result.JobCount = len(openClawJobs)
+				result.Skipped = true
+				return result
+			}
+		}
+	}
+
+	openClawJobs, err := jobsFromPayload(raw)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	hermesJobs := make([]HermesJob, 0, len(openClawJobs))
+	for _, job := range openClawJobs {
+		hj, err := translateOpenClawJobToHermes(job, hermesHome)
+		if err != nil {
+			result.Error = err.Error()
+			return result
+		}
+		hermesJobs = append(hermesJobs, hj)
+	}
+	result.JobCount = len(hermesJobs)
+	if err := upsertHermesManagedJobs(storePath, hermesJobs); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := os.MkdirAll(filepath.Dir(hashPath), 0o750); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := os.WriteFile(hashPath, []byte(sum+"\n"), 0o640); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	return result
+}
+
+func translateOpenClawJobToHermes(job CronJob, hermesHome string) (HermesJob, error) {
+	prompt, model, err := extractHermesPrompt(job)
+	if err != nil {
+		return HermesJob{}, err
+	}
+	schedule, display, err := translateScheduleToHermes(job.Schedule)
+	if err != nil {
+		return HermesJob{}, err
+	}
+	deliver, webhookURL, err := translateDeliveryToHermes(job.Delivery)
+	if err != nil {
+		return HermesJob{}, err
+	}
+	if webhookURL != "" {
+		prompt = appendWebhookInstruction(prompt, webhookURL)
+		if err := writeHermesWebhookURL(hermesHome, job.ID, webhookURL); err != nil {
+			return HermesJob{}, err
+		}
+	}
+
+	now := time.Now().UTC()
+	created := now.Format(time.RFC3339)
+	next := computeHermesNextRunHint(schedule, now)
+	hj := HermesJob{
+		ID:              job.ID,
+		Name:            job.Name,
+		Prompt:          prompt,
+		Schedule:        schedule,
+		Skills:          []string{},
+		Skill:           nil,
+		Deliver:         deliver,
+		Repeat:          map[string]any{"times": nil, "completed": 0},
+		State:           "scheduled",
+		Enabled:         job.Enabled,
+		NextRunAt:       next,
+		LastRunAt:       nil,
+		LastStatus:      nil,
+		CreatedAt:       created,
+		Model:           model,
+		Provider:        nil,
+		Script:          nil,
+		ScheduleDisplay: display,
+	}
+	if !job.Enabled {
+		hj.State = "paused"
+	}
+	if job.DeleteAfterRun {
+		hj.Repeat = map[string]any{"times": 1, "completed": 0}
+	}
+	return hj, nil
+}
+
+func extractHermesPrompt(job CronJob) (string, any, error) {
+	var payload map[string]any
+	if err := json.Unmarshal(job.Payload, &payload); err != nil {
+		return "", nil, fmt.Errorf("hermes translate payload: %w", err)
+	}
+	kind, _ := payload["kind"].(string)
+	var model any
+	if value, ok := payload["model"]; ok {
+		model = value
+	}
+	switch kind {
+	case "agentTurn":
+		message, _ := payload["message"].(string)
+		if strings.TrimSpace(message) == "" {
+			return "", nil, fmt.Errorf("hermes translate: agentTurn message required")
+		}
+		return message, model, nil
+	case "systemEvent":
+		text, _ := payload["text"].(string)
+		if strings.TrimSpace(text) == "" {
+			return "", nil, fmt.Errorf("hermes translate: systemEvent text required")
+		}
+		// Hermes cron always runs an agent prompt; mirror systemEvent as explicit instruction.
+		return "System event (from ClawManager scheduled task):\n" + text, model, nil
+	default:
+		return "", nil, fmt.Errorf("hermes translate: unsupported payload.kind %q", kind)
+	}
+}
+
+func translateScheduleToHermes(raw json.RawMessage) (map[string]any, string, error) {
+	var schedule map[string]any
+	if err := json.Unmarshal(raw, &schedule); err != nil {
+		return nil, "", fmt.Errorf("hermes translate schedule: %w", err)
+	}
+	kind, _ := schedule["kind"].(string)
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "cron":
+		expr, _ := schedule["expr"].(string)
+		expr = strings.TrimSpace(expr)
+		if expr == "" {
+			return nil, "", fmt.Errorf("hermes translate: cron expr required")
+		}
+		return map[string]any{
+			"kind":    "cron",
+			"expr":    expr,
+			"display": expr,
+		}, expr, nil
+	case "every":
+		everyMs, err := asInt64(schedule["everyMs"])
+		if err != nil || everyMs <= 0 {
+			return nil, "", fmt.Errorf("hermes translate: everyMs must be > 0")
+		}
+		minutes := everyMs / 60000
+		if minutes < 1 {
+			minutes = 1
+		}
+		display := fmt.Sprintf("every %dm", minutes)
+		return map[string]any{
+			"kind":    "interval",
+			"minutes": minutes,
+			"display": display,
+		}, display, nil
+	case "at":
+		at, _ := schedule["at"].(string)
+		at = strings.TrimSpace(at)
+		if at == "" {
+			return nil, "", fmt.Errorf("hermes translate: at timestamp required")
+		}
+		display := "once at " + at
+		return map[string]any{
+			"kind":    "once",
+			"run_at":  at,
+			"display": display,
+		}, display, nil
+	default:
+		return nil, "", fmt.Errorf("hermes translate: unsupported schedule.kind %q", kind)
+	}
+}
+
+func translateDeliveryToHermes(raw json.RawMessage) (deliver string, webhookURL string, err error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "origin", "", nil
+	}
+	var delivery map[string]any
+	if err := json.Unmarshal(raw, &delivery); err != nil {
+		return "", "", fmt.Errorf("hermes translate delivery: %w", err)
+	}
+	mode, _ := delivery["mode"].(string)
+	channel, _ := delivery["channel"].(string)
+	to, _ := delivery["to"].(string)
+	channel = strings.TrimSpace(channel)
+	to = strings.TrimSpace(to)
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "announce":
+		if channel == "" || channel == "last" {
+			return "origin", "", nil
+		}
+		if to != "" {
+			return channel + ":" + to, "", nil
+		}
+		return channel, "", nil
+	case "none":
+		return "local", "", nil
+	case "webhook":
+		if to == "" {
+			return "", "", fmt.Errorf("hermes translate: webhook delivery.to required")
+		}
+		return "local", to, nil
+	default:
+		return "", "", fmt.Errorf("hermes translate: unsupported delivery.mode %q", mode)
+	}
+}
+
+func appendWebhookInstruction(prompt, webhookURL string) string {
+	return prompt + "\n\n[ClawManager delivery.webhook]\n" +
+		"After you finish, POST your complete final answer as JSON {\"text\": \"...\"} to " +
+		webhookURL +
+		" using an available HTTP tool. Treat webhook delivery as required."
+}
+
+func writeHermesWebhookURL(hermesHome, jobID, webhookURL string) error {
+	dir := filepath.Join(hermesHome, "cron", "webhooks")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, jobID+".url"), []byte(webhookURL+"\n"), 0o640)
+}
+
+func computeHermesNextRunHint(schedule map[string]any, now time.Time) *string {
+	kind, _ := schedule["kind"].(string)
+	switch kind {
+	case "once":
+		if runAt, ok := schedule["run_at"].(string); ok && strings.TrimSpace(runAt) != "" {
+			value := strings.TrimSpace(runAt)
+			return &value
+		}
+	case "interval", "cron":
+		value := now.UTC().Format(time.RFC3339)
+		return &value
+	}
+	value := now.UTC().Format(time.RFC3339)
+	return &value
+}
+
+func upsertHermesManagedJobs(storePath string, managed []HermesJob) error {
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o750); err != nil {
+		return fmt.Errorf("create hermes cron dir: %w", err)
+	}
+	existing, err := loadHermesJobs(storePath)
+	if err != nil {
+		return err
+	}
+	kept := make([]HermesJob, 0, len(existing.Jobs))
+	existingByID := map[string]HermesJob{}
+	for _, job := range existing.Jobs {
+		existingByID[job.ID] = job
+		if strings.HasPrefix(job.ID, ManagedJobIDPrefix) {
+			continue
+		}
+		kept = append(kept, job)
+	}
+	for _, job := range managed {
+		if prev, ok := existingByID[job.ID]; ok {
+			job.CreatedAt = prev.CreatedAt
+			job.LastRunAt = prev.LastRunAt
+			job.LastStatus = prev.LastStatus
+			if prev.Repeat != nil {
+				if completed, ok := prev.Repeat["completed"]; ok {
+					job.Repeat["completed"] = completed
+				}
+			}
+		}
+		kept = append(kept, job)
+	}
+	return saveHermesJobs(storePath, HermesJobsFile{
+		Jobs:      kept,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func loadHermesJobs(path string) (HermesJobsFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return HermesJobsFile{Jobs: []HermesJob{}}, nil
+		}
+		return HermesJobsFile{}, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return HermesJobsFile{Jobs: []HermesJob{}}, nil
+	}
+	var asObject HermesJobsFile
+	if err := json.Unmarshal(data, &asObject); err == nil {
+		if asObject.Jobs == nil {
+			asObject.Jobs = []HermesJob{}
+		}
+		return asObject, nil
+	}
+	var asList []HermesJob
+	if err := json.Unmarshal(data, &asList); err != nil {
+		return HermesJobsFile{}, fmt.Errorf("parse hermes cron store: %w", err)
+	}
+	return HermesJobsFile{Jobs: asList}, nil
+}
+
+func saveHermesJobs(path string, file HermesJobsFile) error {
+	raw, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(raw, '\n'), 0o640); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func asInt64(value any) (int64, error) {
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed), nil
+	case int64:
+		return typed, nil
+	case int:
+		return int64(typed), nil
+	case json.Number:
+		return typed.Int64()
+	case string:
+		return strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+	default:
+		return 0, fmt.Errorf("not an int")
+	}
+}
+
+func sha256Sum(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary
- 新增 scheduled-tasks apply 链路，将 ClawManager 下发的 `*_SCHEDULED_TASKS_JSON` 同步到 Hermes / OpenClaw 的 cron store（托管 job 前缀 `cm-st-`）
- 在 clawmanager-agent config writer、OpenClaw configmanager、Hermes `hermes-apply-runtime-config` 中接入 apply，并补齐相关单测
- 适配 Hermes 新版启动/配置：Dashboard Basic Auth 自动注入（避免依赖废弃 `--insecure`），补充 nosyntax / pro-overlay 镜像与 gateway 启动脚本调整
## Test plan
- [ ] 注入 `CLAWMANAGER_HERMES_SCHEDULED_TASKS_JSON` / `CLAWMANAGER_OPENCLAW_SCHEDULED_TASKS_JSON`，确认 `cron/jobs.json` 出现 `cm-st-*` 托管任务
- [ ] 重复 apply 同一 payload，确认可跳过且不破坏用户自建 cron job
- [ ] 变更 payload 后再次 apply，确认托管任务被更新，非托管任务保留
- [ ] Hermes 实例无显式 Basic Auth 时，确认自动注入 username/password，dashboard 可在 `0.0.0.0` 绑定访问
- [ ] 构建/启动 Hermes、OpenClaw agent/pro overlay 镜像，确认 gateway / dashboard 正常拉起
- [ ] 跑相关单测：`scheduledtasks`、`hermes profile`、`openclaw config_writer`、`hermes/rootfs_scripts_test`